### PR TITLE
Make Field a fake built class so a class builder can be used for subclasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,13 @@ You could also choose to yield tuples of `name, value` pairs in your implementat
 ### What if I want to exclude fields from a method? ###
 
 In order to exclude fields you first need to extend the `Field` class
-to add a new attribute. Thankfully there is a convenience `fieldclass_maker`
-function to assist in this.
+to add a new attribute. Thankfully the `@fieldclass` decorator can be used
+to extend `Field` in the same way as `@slotclass` works for regular classes.
+
+This special class builder is needed to treat `NOTHING` sentinel values as
+regular values in the `__init__` generator. As such this is only intended
+for use on `Field` subclasses.
+
 You also need to rewrite the code generator to check for the new attribute 
 and exclude the field if it is `False`.
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Here is an example of adding the ability to exclude fields from `__repr__`.
 ```python
 from ducktools.classbuilder import (
     eq_desc,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     init_desc,
     slotclass,
@@ -190,7 +190,9 @@ from ducktools.classbuilder import (
 )
 
 
-FieldExt = fieldclass_maker("FieldExt", repr=True)
+@fieldclass
+class FieldExt(Field):
+    __slots__ = SlotFields(repr=True)
 
 
 def repr_exclude_maker(cls):
@@ -414,19 +416,19 @@ errors when the `__init__` method is generated.
 from ducktools.classbuilder import (
     builder,
     eq_desc,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     slot_gatherer,
+    Field,
     SlotFields,
     NOTHING,
     MethodMaker,
 )
 
 
-PosOnlyField = fieldclass_maker(
-    "PosOnlyField",
-    pos_only=True,
-)
+@fieldclass
+class PosOnlyField(Field):
+    __slots__ = SlotFields(pos_only=True)
 
 
 def init_maker(cls):
@@ -554,15 +556,18 @@ their attribute is set.
 from ducktools.classbuilder import (
     builder,
     default_methods,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     slot_gatherer,
+    Field,
     SlotFields,
     MethodMaker,
 )
 
 
-ConverterField = fieldclass_maker("ConverterField", converter=None)
+@fieldclass
+class ConverterField(Field):
+    __slots__ = SlotFields(converter=None)
 
 
 def setattr_maker(cls):
@@ -606,7 +611,6 @@ if __name__ == "__main__":
 
     ex = ConverterEx("42", "42")
     print(ex)
-
 ```
 
 

--- a/readme_code/readme_ex4_exclude_repr.py
+++ b/readme_code/readme_ex4_exclude_repr.py
@@ -1,17 +1,18 @@
 from ducktools.classbuilder import (
     eq_desc,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     init_desc,
     slotclass,
     Field,
     SlotFields,
-    NOTHING,
     MethodMaker,
 )
 
 
-FieldExt = fieldclass_maker("FieldExt", repr=True)
+@fieldclass
+class FieldExt(Field):
+    __slots__ = SlotFields(repr=True)
 
 
 def repr_exclude_maker(cls):

--- a/readme_code/readme_ex7_posonly.py
+++ b/readme_code/readme_ex7_posonly.py
@@ -1,19 +1,19 @@
 from ducktools.classbuilder import (
     builder,
     eq_desc,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     slot_gatherer,
+    Field,
     SlotFields,
     NOTHING,
     MethodMaker,
 )
 
 
-PosOnlyField = fieldclass_maker(
-    "PosOnlyField",
-    pos_only=True,
-)
+@fieldclass
+class PosOnlyField(Field):
+    __slots__ = SlotFields(pos_only=True)
 
 
 def init_maker(cls):

--- a/readme_code/readme_ex8_converters.py
+++ b/readme_code/readme_ex8_converters.py
@@ -1,15 +1,18 @@
 from ducktools.classbuilder import (
     builder,
     default_methods,
-    fieldclass_maker,
+    fieldclass,
     get_fields,
     slot_gatherer,
+    Field,
     SlotFields,
     MethodMaker,
 )
 
 
-ConverterField = fieldclass_maker("ConverterField", converter=None)
+@fieldclass
+class ConverterField(Field):
+    __slots__ = SlotFields(converter=None)
 
 
 def setattr_maker(cls):

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -323,4 +323,9 @@ def fieldclass(cls):
     )
     field_methods = frozenset({field_init_desc, repr_desc, eq_desc})
 
-    return slotclass(cls, methods=field_methods, default_check=False)
+    return builder(
+        cls,
+        gatherer=slot_gatherer,
+        methods=field_methods,
+        default_check=False
+    )

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -40,103 +40,6 @@ class _NothingType:
 NOTHING = _NothingType()
 
 
-class Field:
-    """
-    A basic class to handle the assignment of defaults/factories with
-    some metadata.
-
-    Intended to be extendable by subclasses for additional features.
-
-    __repr__ and __eq__ methods will extend to include any additional
-    __slots__ values defined in subclasses.
-    """
-    __slots__ = ("default", "default_factory", "type", "doc")
-
-    # noinspection PyShadowingBuiltins
-    def __init__(
-        self,
-        *,
-        default=NOTHING,
-        default_factory=NOTHING,
-        type=NOTHING,
-        doc=None,
-    ):
-        self.default = default
-        self.default_factory = default_factory
-        self.type = type
-        self.doc = doc
-
-    @property
-    def _inherited_slots(self):
-        fields = []
-        for cls in reversed(self.__class__.__mro__):
-            fields.extend(getattr(cls, "__slots__", ()))
-        return fields
-
-    def __repr__(self):
-        flds = ", ".join(
-            f"{field}={getattr(self, field)!r}"
-            for field in self._inherited_slots
-        )
-        return (
-            f"{self.__class__.__name__}({flds})"
-        )
-
-    def __eq__(self, other):
-        if type(self) is type(other):
-            return all(
-                getattr(self, field) == getattr(other, field)
-                for field in self._inherited_slots
-            )
-        return NotImplemented
-
-
-def fieldclass_maker(__classname, /, **new_fields):
-    """
-    Create a new `Field` subclass with additional
-    fields and default values.
-
-    :param __classname: name of the new `Field` subclass
-    :param new_fields: fieldname=default keys
-    :return: a new Field subclass
-    """
-    args = {
-        "default": NOTHING,
-        "default_factory": NOTHING,
-        "type": NOTHING,
-        "doc": None,
-    }
-    args.update(new_fields)
-
-    globs = {}
-    arglist = []
-    assignments = []
-
-    for k, v in args.items():
-        globs[f"_{k}_default"] = v
-        arg = f"{k}=_{k}_default"
-        assignment = f"self.{k} = {k}"
-
-        arglist.append(arg)
-        assignments.append(assignment)
-
-    args = ", ".join(arglist)
-    assigns = "\n    ".join(assignments)
-    code = f"def __init__(self, {args}):\n" f"    {assigns}\n"
-
-    locs = {}
-    exec(code, globs, locs)
-    init_func = locs.get("__init__")
-    slots = tuple(k for k in new_fields)
-
-    class_dict = {
-        "__init__": init_func,
-        "__slots__": slots,
-    }
-
-    return type(__classname, (Field, ), class_dict)
-
-
 class MethodMaker:
     """
     The descriptor class to place where methods should be generated.
@@ -167,7 +70,7 @@ class MethodMaker:
         return method.__get__(instance, cls)
 
 
-def init_maker(cls):
+def init_maker(cls, *, null=NOTHING):
     fields = get_fields(cls)
 
     arglist = []
@@ -175,11 +78,11 @@ def init_maker(cls):
     globs = {}
 
     for k, v in fields.items():
-        if v.default is not NOTHING:
+        if v.default is not null:
             globs[f"_{k}_default"] = v.default
             arg = f"{k}=_{k}_default"
             assignment = f"self.{k} = {k}"
-        elif v.default_factory is not NOTHING:
+        elif v.default_factory is not null:
             globs[f"_{k}_factory"] = v.default_factory
             arg = f"{k}=None"
             assignment = f"self.{k} = _{k}_factory() if {k} is None else {k}"
@@ -287,7 +190,58 @@ def builder(cls, /, *, gatherer, methods, default_check=True):
     return cls
 
 
-# Example code of a slot-based boilerplate generator.
+class Field:
+    """
+    A basic class to handle the assignment of defaults/factories with
+    some metadata.
+
+    Intended to be extendable by subclasses for additional features.
+
+    __repr__ and __eq__ methods will extend to include any additional
+    __slots__ values defined in subclasses.
+    """
+    __slots__ = {
+        "default": "Standard default value to be used for attributes with"
+                   "this field.",
+        "default_factory": "A 0 argument function to be called to generate "
+                           "a default value, useful for mutable objects like "
+                           "lists.",
+        "type": "The type of the attribute to be assigned by this field.",
+        "doc": "The documentation that appears when calling help(...) on the class."
+    }
+
+    # noinspection PyShadowingBuiltins
+    def __init__(
+        self,
+        *,
+        default=NOTHING,
+        default_factory=NOTHING,
+        type=NOTHING,
+        doc=None,
+    ):
+        self.default = default
+        self.default_factory = default_factory
+        self.type = type
+        self.doc = doc
+
+
+# Use the builder to generate __repr__ and __eq__ methods
+# and pretend `Field` was a built class all along.
+_field_internal = {
+    "default": Field(default=NOTHING),
+    "default_factory": Field(default=NOTHING),
+    "type": Field(default=NOTHING),
+    "doc": Field(default=None),
+}
+
+builder(
+    Field,
+    gatherer=lambda cls_: _field_internal,
+    methods=frozenset({repr_desc, eq_desc}),
+    default_check=False
+)
+
+
 # Subclass of dict to be identifiable by isinstance checks
 # For anything more complicated this could be made into a Mapping
 class SlotFields(dict):
@@ -328,14 +282,45 @@ def slot_gatherer(cls):
     return cls_fields
 
 
-def slotclass(cls=None, /, *, methods=default_methods):
+def slotclass(cls=None, /, *, methods=default_methods, default_check=True):
     """
     Example of class builder in action using __slots__ to find fields.
 
     :param cls: Class to be analysed and modified
     :param methods: MethodMakers to be added to the class
+    :param default_check: check there are no arguments without defaults
+                          after arguments with defaults.
     :return: Modified class
     """
     if cls is None:
-        return lambda cls_: builder(cls_, gatherer=slot_gatherer, methods=methods)
-    return builder(cls, gatherer=slot_gatherer, methods=methods)
+        return lambda cls_: builder(
+            cls_,
+            gatherer=slot_gatherer,
+            methods=methods,
+            default_check=default_check
+        )
+    return builder(
+        cls,
+        gatherer=slot_gatherer,
+        methods=methods,
+        default_check=default_check
+    )
+
+
+def fieldclass(cls):
+    """
+    This is a special decorator for making Field subclasses using __slots__.
+    This works by forcing the __init__ method to treat NOTHING as a regular
+    value. This means *all* instance attributes always have defaults.
+
+    :param cls: Field subclass
+    :return: Modified subclass
+    """
+    field_nothing = _NothingType()
+    field_init_desc = MethodMaker(
+        "__init__",
+        lambda cls_: init_maker(cls_, null=field_nothing)
+    )
+    field_methods = frozenset({field_init_desc, repr_desc, eq_desc})
+
+    return slotclass(cls, methods=field_methods, default_check=False)

--- a/src/ducktools/classbuilder/__init__.pyi
+++ b/src/ducktools/classbuilder/__init__.pyi
@@ -10,33 +10,6 @@ class _NothingType:
     ...
 NOTHING: _NothingType
 
-class Field:
-    default: _NothingType | typing.Any
-    default_factory: _NothingType | typing.Any
-    type: _NothingType | type
-    doc: None | str
-
-    def __init__(
-        self,
-        *,
-        default: _NothingType | typing.Any = NOTHING,
-        default_factory: _NothingType | typing.Any = NOTHING,
-        type: _NothingType | type = NOTHING,
-        doc: None | str = None,
-    ) -> None: ...
-    @property
-    def _inherited_slots(self) -> list[str]: ...
-    def __repr__(self) -> str: ...
-    @typing.overload
-    def __eq__(self, other: Field) -> bool: ...
-    @typing.overload
-    def __eq__(self, other: object) -> NotImplemented: ...
-
-# Really this will return a subclass of field with additional fields
-# But I don't know how to make typing understand this so `any` will do
-# for now.
-def fieldclass_maker(__classname: str, /, **new_fields: typing.Any) -> typing.Any: ...
-
 # Stub Only
 _codegen_type = Callable[[type], tuple[str, dict[str, typing.Any]]]
 
@@ -62,8 +35,32 @@ def builder(
     *,
     gatherer: Callable[[type], dict[str, Field]],
     methods: frozenset[MethodMaker],
-    default_check: bool =True,
+    default_check: bool = True,
 ) -> type: ...
+
+
+class Field:
+    default: _NothingType | typing.Any
+    default_factory: _NothingType | typing.Any
+    type: _NothingType | type
+    doc: None | str
+
+    def __init__(
+        self,
+        *,
+        default: _NothingType | typing.Any = NOTHING,
+        default_factory: _NothingType | typing.Any = NOTHING,
+        type: _NothingType | type = NOTHING,
+        doc: None | str = None,
+    ) -> None: ...
+    @property
+    def _inherited_slots(self) -> list[str]: ...
+    def __repr__(self) -> str: ...
+    @typing.overload
+    def __eq__(self, other: Field) -> bool: ...
+    @typing.overload
+    def __eq__(self, other: object) -> NotImplemented: ...
+
 
 class SlotFields(dict):
     ...
@@ -76,4 +73,7 @@ def slotclass(
     /,
     *,
     methods: frozenset[MethodMaker] = default_methods,
+    default_check: bool = True
 ) -> type: ...
+
+def fieldclass(cls: type) -> type: ...


### PR DESCRIPTION
This replaces the class specific code generation with the same code generation used for regular classes.

In order to subclass `Field` you need to use `@fieldclass` in order to treat `NOTHING` values as regular defaults instead of special values.