### PR TITLE
Expand the build_prefab function

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -368,7 +368,7 @@ class GatheredFields:
 
     def __repr__(self):
         return (
-            f"{type(self.__name__)}("
+            f"{type(self).__name__}("
             f"fields={self.fields!r}, "
             f"modifications={self.modifications!r}"
             f")"

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 import sys
 
-__version__ = "v0.5.0"
+__version__ = "v0.5.1"
 
 # Change this name if you make heavy modifications
 INTERNALS_DICT = "__classbuilder_internals__"
@@ -359,6 +359,30 @@ class Field:
         return cls(**argument_dict)
 
 
+class GatheredFields:
+    __slots__ = ("fields", "modifications")
+
+    def __init__(self, fields, modifications):
+        self.fields = fields
+        self.modifications = modifications
+
+    def __repr__(self):
+        return (
+            f"{type(self.__name__)}("
+            f"fields={self.fields!r}, "
+            f"modifications={self.modifications!r}"
+            f")"
+        )
+
+    def __eq__(self, other):
+        if type(self) is type(other):
+            return (self.fields, self.modifications) == (other.fields, other.modifications)
+        return NotImplemented
+
+    def __call__(self, cls):
+        return self.fields, self.modifications
+
+
 # Use the builder to generate __repr__ and __eq__ methods
 # and pretend `Field` was a built class all along.
 _field_internal = {
@@ -374,7 +398,7 @@ if _UNDER_TESTING:
 
 builder(
     Field,
-    gatherer=lambda cls_: (_field_internal, {}),
+    gatherer=GatheredFields(_field_internal, {}),
     methods=_field_methods,
     flags={"slotted": True, "kw_only": True},
 )

--- a/src/ducktools/classbuilder/__init__.pyi
+++ b/src/ducktools/classbuilder/__init__.pyi
@@ -92,6 +92,19 @@ class Field:
     def from_field(cls, fld: Field, /, **kwargs: typing.Any) -> Field: ...
 
 
+class GatheredFields:
+    __slots__ = ("fields", "modifications")
+    def __init__(
+        self,
+        fields: dict[str, Field],
+        modifications: dict[str, typing.Any]
+    ) -> None: ...
+
+    def __repr__(self) -> str: ...
+    def __eq__(self, other) -> bool: ...
+    def __call__(self, cls: type) -> tuple[dict[str, Field], dict[str, typing.Any]]: ...
+
+
 class SlotFields(dict):
     ...
 

--- a/src/ducktools/classbuilder/__init__.pyi
+++ b/src/ducktools/classbuilder/__init__.pyi
@@ -94,6 +94,12 @@ class Field:
 
 class GatheredFields:
     __slots__ = ("fields", "modifications")
+
+    fields: dict[str, Field]
+    modifications: dict[str, typing.Any]
+
+    __classbuilder_internals__: dict
+
     def __init__(
         self,
         fields: dict[str, Field],

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -109,6 +109,7 @@ def _make_prefab(
     frozen: bool = False,
     dict_method: bool = False,
     recursive_repr: bool = False,
+    gathered_fields: Callable[[type], tuple[dict[str, Attribute], dict[str, typing.Any]]] | None = None,
 ) -> type: ...
 
 _T = typing.TypeVar("_T")
@@ -146,6 +147,7 @@ def build_prefab(
     frozen: bool = False,
     dict_method: bool = False,
     recursive_repr: bool = False,
+    slots: bool = False,
 ) -> type: ...
 
 def is_prefab(o: typing.Any) -> bool: ...

--- a/tests/prefab/dynamic/test_construction.py
+++ b/tests/prefab/dynamic/test_construction.py
@@ -91,3 +91,25 @@ def test_kwonly_class():
         a: int = 0
         b: int = attribute(kw_only=True)
         c: int = attribute()  # kw_only should be ignored
+
+
+def test_build_slotted():
+    SlottedClass = build_prefab(
+        "SlottedClass",
+        [
+            ("x", attribute(doc="x co-ordinate", type=float)),
+            ("y", attribute(default=0, doc="y co-ordinate", type=float))
+        ],
+        slots=True,
+    )
+
+    inst = SlottedClass(1)
+    assert inst.x == 1
+    assert inst.y == 0
+    assert SlottedClass.__slots__ == {'x': "x co-ordinate", 'y': "y co-ordinate"}
+
+    assert SlottedClass.__annotations__ == {'x': float, 'y': float}
+
+    # Test slots are functioning
+    with pytest.raises(AttributeError):
+        inst.z = 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,7 @@ from ducktools.classbuilder import (
     slot_gatherer,
     slotclass,
     fieldclass,
+    GatheredFields,
 )
 
 
@@ -374,3 +375,31 @@ def test_builder_noclass():
     assert x.a == 12
     assert x.b == 2
     assert x.c == []
+
+
+def test_gatheredfields():
+    fields = {"x": Field(default=1)}
+    modifications = {"x": NOTHING}
+
+    alt_fields = {"x": Field(default=1), "y": Field(default=2)}
+
+    flds = GatheredFields(fields, modifications)
+    flds_2 = GatheredFields(fields, modifications)
+    flds_3 = GatheredFields(alt_fields, modifications)
+
+    class Ex:
+        pass
+
+    assert flds(Ex) == (fields, modifications)
+
+    assert flds == flds_2
+    assert flds != alt_fields
+    assert flds != object()
+
+    assert repr(flds).endswith(
+        "GatheredFields("
+        "fields={'x': Field(default=1, default_factory=<NOTHING OBJECT>, type=<NOTHING OBJECT>, doc=None)}, "
+        "modifications={'x': <NOTHING OBJECT>}"
+        ")"
+    )
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -300,6 +300,46 @@ def test_slotclass_norepr_noeq():
     assert "__eq__" not in SlotClass.__dict__
 
 
+def test_slotclass_weakref():
+    @slotclass
+    class WeakrefClass:
+        __slots__ = SlotFields(
+            a=1,
+            b=2,
+            __weakref__=None,
+        )
+
+    flds = get_fields(WeakrefClass)
+    assert 'a' in flds
+    assert 'b' in flds
+    assert '__weakref__' not in flds
+
+    slots = WeakrefClass.__slots__
+    assert 'a' in slots
+    assert 'b' in slots
+    assert '__weakref__' in slots
+
+
+def test_slotclass_dict():
+    @slotclass
+    class DictClass:
+        __slots__ = SlotFields(
+            a=1,
+            b=2,
+            __dict__=None,
+        )
+
+    flds = get_fields(DictClass)
+    assert 'a' in flds
+    assert 'b' in flds
+    assert '__dict__' not in flds
+
+    slots = DictClass.__slots__
+    assert 'a' in slots
+    assert 'b' in slots
+    assert '__dict__' in slots
+
+
 def test_fieldclass():
     @fieldclass
     class NewField(Field):
@@ -393,7 +433,7 @@ def test_gatheredfields():
     assert flds(Ex) == (fields, modifications)
 
     assert flds == flds_2
-    assert flds != alt_fields
+    assert flds != flds_3
     assert flds != object()
 
     assert repr(flds).endswith(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -301,6 +301,8 @@ def test_slotclass_norepr_noeq():
 
 
 def test_slotclass_weakref():
+    import weakref
+
     @slotclass
     class WeakrefClass:
         __slots__ = SlotFields(
@@ -318,6 +320,11 @@ def test_slotclass_weakref():
     assert 'a' in slots
     assert 'b' in slots
     assert '__weakref__' in slots
+
+    # Test weakrefs can be created
+    inst = WeakrefClass()
+    ref = weakref.ref(inst)
+    assert ref == inst.__weakref__
 
 
 def test_slotclass_dict():
@@ -338,6 +345,11 @@ def test_slotclass_dict():
     assert 'a' in slots
     assert 'b' in slots
     assert '__dict__' in slots
+
+    # Test if __dict__ is included new values can be added
+    inst = DictClass()
+    inst.c = 42
+    assert inst.__dict__ == {"c": 42}
 
 
 def test_fieldclass():


### PR DESCRIPTION
`build_prefab` now skips the gathering stage of `@prefab` as the values are provided, it will still set `__annotations__` as expected. 

It also now has a `slots` argument which can be used to create classes that use slots. This argument **will not** exist in the standard `prefab(...)` call as slots support is provided by declaring the class using `__slots__ = SlotFields(...)` rather than by an argument to `prefab`.

As an internal change there is now a `GatheredFields` class in the core which is used to provide to `builder` a callable that returns previously gathered fields and modifications. This is now used to add the additional methods to `Field` and `GatheredFields` itself.