### PR TITLE
Fix for MethodMaker descriptors being called via super()

### DIFF
--- a/docs/approach_vs_tool.md
+++ b/docs/approach_vs_tool.md
@@ -4,13 +4,27 @@ As this module's code generation is inspired by the workings of [David Beazley's
 I thought it was briefly worth discussing his note on learning an approach vs using a tool.
 
 I think that learning an approach is valuable, this module would not exist without the
-example given by `cluegen`. It also wouldn't exist if I hadn't needed to extend `cluegen`
-for some basic features (try using `Path` default values with `cluegen`).
+example given by `cluegen`.
+
+However, what I foundn was that in essentially every case where I wanted to use 
+these generating tools, I needed to modify them - often significantly. 
+It quickly became easier to just create my own tool and upload it as a package.
+
+For example, `cluegen` has a few subtle "exercises for the reader". It needs extending
+and fixing for some use-cases.
+   * Default values that are not builtins need to be passed as part of the globals 
+     dict to `exec`.
+   * No support for mutable defaults.
+   * Subclass methods will be overwritten if they call a cluegen method that has not been
+     generated via `super().methodname(...)`
+   * `inspect.signature(cls)` does not work if `cls.__init__` has not already been generated.
+     (I think this is actually a bug in inspect).
+   * Need an extra filter to support things like `ClassVar`.
 
 In the general spirit though, this module intends to provide some basic tools to help 
-build your own custom class generators.
+create your own customized boilerplate generators.
 The generator included in the base module is intended to be used to help 'bootstrap' a 
 modified generator with features that work how **you** want them to work.
 
-The `prefab` module is the more fully featured powertool *I* built with these tools. 
-However, much like a prefabricated building, it may not be what you desire.
+The `prefab` module is the more fully featured tool that handles the additional cases *I*
+needed. 


### PR DESCRIPTION
If a generated method was called via `super()` previously it would overwrite the calling method.

This is because the descriptor `get(...)` method would be called with `get(subclass_inst, subclass)` instead of `get(inst, class)`. The generator would run on the subclass and then overwrite the subclass method.

This patch checks if `subclass.funcname` is the MethodMaker object and only overwrites if that matches, if it does not it checks the MRO until it finds the method maker and calls that on its own class to generate the method.