### PR TITLE
Add private parameter to prefab's attribute function

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -34,7 +34,7 @@ import sys
 
 from .annotations import get_ns_annotations, is_classvar
 
-__version__ = "v0.6.2"
+__version__ = "v0.6.3"
 
 # Change this name if you make heavy modifications
 INTERNALS_DICT = "__classbuilder_internals__"

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -294,6 +294,7 @@ def attribute(
     kw_only=False,
     serialize=True,
     exclude_field=False,
+    private=False,
     doc=None,
     type=NOTHING,
 ):
@@ -310,12 +311,22 @@ def attribute(
     :param kw_only: Make this argument keyword only in init
     :param serialize: Include this attribute in methods that serialize to dict
     :param exclude_field: Shorthand for setting repr, compare, iter and serialize to False
+    :param private: Short for init, repr, compare, iter, serialize = False, must have default or factory
     :param doc: Parameter documentation for slotted classes
     :param type: Type of this attribute (for slotted classes)
 
     :return: Attribute generated with these parameters.
     """
     if exclude_field:
+        repr = False
+        compare = False
+        iter = False
+        serialize = False
+
+    if private:
+        if default is NOTHING and default_factory is NOTHING:
+            raise AttributeError("Private attributes must have defaults or factories.")
+        init = False
         repr = False
         compare = False
         iter = False

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -81,6 +81,7 @@ def attribute(
     kw_only: bool = False,
     serialize: bool = True,
     exclude_field: bool = False,
+    private: bool = False,
 ) -> Attribute: ...
 
 def prefab_gatherer(cls_or_ns: type | MappingProxyType) -> tuple[dict[str, Attribute], dict[str, typing.Any]]: ...

--- a/tests/prefab/dynamic/test_private.py
+++ b/tests/prefab/dynamic/test_private.py
@@ -3,7 +3,7 @@ from ducktools.classbuilder.prefab import Prefab, attribute, get_attributes
 
 def test_private_attribute():
     class Ex(Prefab):
-        _internal: str | None = attribute(default=None, private=True)
+        _internal: "str | None" = attribute(default=None, private=True)
         a: int
         b: str
 

--- a/tests/prefab/dynamic/test_private.py
+++ b/tests/prefab/dynamic/test_private.py
@@ -1,0 +1,24 @@
+from ducktools.classbuilder.prefab import Prefab, attribute, get_attributes
+
+
+def test_private_attribute():
+    class Ex(Prefab):
+        _internal: str | None = attribute(default=None, private=True)
+        a: int
+        b: str
+
+
+    ex = Ex(1, "Hello")
+
+    assert ex.a == 1
+    assert ex.b == "Hello"
+
+    assert ex._internal is None
+
+    _internal_attrib = get_attributes(Ex)["_internal"]
+
+    assert _internal_attrib.init is False
+    assert _internal_attrib.repr is False
+    assert _internal_attrib.iter is False
+    assert _internal_attrib.compare is False
+    assert _internal_attrib.serialize is False


### PR DESCRIPTION
Add a private parameter to prefab's `attribute` function that sets *everything* to false and requires a default or factory.

This is intended for attributes that need to exist to store cached values from properties.