### PR TITLE
Add preliminary support for 3.14 __annotate__

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Operating System :: OS Independent",
     "License :: OSI Approved :: MIT License",
 ]

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -707,10 +707,6 @@ def make_slot_gatherer(field_type=Field):
                 "in order to generate a slotclass"
             )
 
-        # Don't want to mutate original annotations so make a copy if it exists
-        # Looking at the dict is a Python3.9 or earlier requirement
-        cls_annotations = get_ns_annotations(cls_dict)
-
         cls_fields = {}
         slot_replacement = {}
 
@@ -724,8 +720,6 @@ def make_slot_gatherer(field_type=Field):
 
             if isinstance(v, field_type):
                 attrib = v
-                if attrib.type is not NOTHING:
-                    cls_annotations[k] = attrib.type
             else:
                 # Plain values treated as defaults
                 attrib = field_type(default=v)
@@ -738,7 +732,6 @@ def make_slot_gatherer(field_type=Field):
         # In this case, slots with documentation and new annotations.
         modifications = {
             "__slots__": slot_replacement,
-            "__annotations__": cls_annotations,
         }
 
         return cls_fields, modifications

--- a/src/ducktools/classbuilder/annotations.pyi
+++ b/src/ducktools/classbuilder/annotations.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import typing
 import types
 
@@ -6,6 +7,11 @@ _CopiableMappings = dict[str, typing.Any] | types.MappingProxyType[str, typing.A
 
 class _StringGlobs(dict):
     def __missing__(self, key: _T) -> _T: ...
+
+
+def call_annotate_func(
+        annotate: Callable[[int], dict[str, type | typing.ForwardRef]]
+) -> dict[str, type | str]: ...
 
 
 def eval_hint(

--- a/tests/annotations/test_future_annotations.py
+++ b/tests/annotations/test_future_annotations.py
@@ -1,4 +1,4 @@
-# Bare forwardrefs only work in 3.14 or later
+from __future__ import annotations
 
 from ducktools.classbuilder.annotations import get_ns_annotations
 
@@ -36,10 +36,10 @@ def test_inner_outer_ref():
 
     cls, annos = make_func()
 
-    # Forwardref given as string if used before it can be evaluated
-    assert annos == {"a_val": str, "b_val": int, "c_val": "hyper_type"}
+    # Only global types can be evaluated
+    assert annos == {"a_val": "inner_type", "b_val": int, "c_val": "hyper_type"}
 
-    # Correctly evaluated if it exists
+    # No extra evaluation
     assert get_ns_annotations(cls.__dict__) == {
-        "a_val": str, "b_val": int, "c_val": float
+        "a_val": "inner_type", "b_val": int, "c_val": "hyper_type"
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,9 @@ import sys
 
 collect_ignore = []
 
-if sys.version_info < (3, 14):
+if sys.version_info < (3, 15):
     minor_ver = sys.version_info.minor
 
     collect_ignore.extend(
-        f"py3{i+1}_tests" for i in range(minor_ver, 14)
+        f"py3{i+1}_tests" for i in range(minor_ver, 15)
     )

--- a/tests/prefab/dynamic/test_slotted_class.py
+++ b/tests/prefab/dynamic/test_slotted_class.py
@@ -13,7 +13,6 @@ def test_basic_slotted():
         )
 
     assert SlottedPrefab.__slots__ == {"x": None, "y": "Digits of pi"}
-    assert get_ns_annotations(SlottedPrefab.__dict__) == {"y": float}
 
     ex = SlottedPrefab()
 

--- a/tests/py314_tests/test_forwardref_annotations.py
+++ b/tests/py314_tests/test_forwardref_annotations.py
@@ -1,0 +1,45 @@
+# Bare forwardrefs only work in 3.14 or later
+
+from ducktools.classbuilder.annotations import get_ns_annotations
+
+from pathlib import Path
+
+
+def test_bare_forwardref():
+    class Ex:
+        a: str
+        b: Path
+        c: plain_forwardref
+
+    annos = get_ns_annotations(Ex.__dict__)
+
+    assert annos == {'a': str, 'b': Path, 'c': "plain_forwardref"}
+
+
+def test_inner_outer_ref():
+    outer_type = int
+
+    def make_func():
+        inner_type = str
+
+        class Inner:
+            a_val: inner_type = "hello"
+            b_val: outer_type = 42
+            c_val: hyper_type = 3.14
+
+        # Try to get annotations before hyper_type exists
+        annos = get_ns_annotations(Inner.__dict__)
+
+        hyper_type = float
+
+        return Inner, annos
+
+    cls, annos = make_func()
+
+    # Forwardref given as string if used before it can be evaluated
+    assert annos == {"a_val": str, "b_val": int, "c_val": "hyper_type"}
+
+    # Correctly evaluated if it exists
+    assert get_ns_annotations(cls.__dict__) == {
+        "a_val": str, "b_val": int, "c_val": float
+    }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -188,7 +188,6 @@ def test_slot_gatherer_success():
 
     assert slots == fields
     assert modifications["__slots__"] == {"a": None, "b": None, "c": "a list", "d": None}
-    assert modifications["__annotations__"] == {"a": int, "d": str}
     assert get_ns_annotations(SlotsExample.__dict__) == {"a": int}  # Original annotations dict unmodified
 
 


### PR DESCRIPTION
PEP649 changes the way annotations work and no longer guarantees `__annotations__` will be in the class dictionary currently. This patch checks for `__annotate__` first and falls back to `__annotations__` if it does not exist. 

I'd like to have something in early because classbuilder will be included in 'env' bundles and I'd like those to continue working when Python is updated to 3.14.