### PR TITLE
Add graalpy to the test matrix

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13-dev", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8"]
+        python-version: ["3.13-dev", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8", "graalpy-24"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Testing against PyPy did catch some differences in implementation that would have broken classbuilder under it, perhaps it's worth testing against graalpy similarly as it would be nice if classbuilder worked everywhere.