### PR TITLE
Add example to documentation / Change default to removing default values for gatherers

### DIFF
--- a/docs/extension_examples.md
+++ b/docs/extension_examples.md
@@ -259,6 +259,138 @@ if __name__ == "__main__":
         print(e)
 ```
 
+#### Frozen Attributes ####
+
+Here's an implementation that allows freezing of individual attributes.
+
+```python
+import ducktools.classbuilder as dtbuild
+
+
+class FreezableField(dtbuild.Field):
+    frozen: bool = False
+
+
+def setattr_generator(cls, funcname="__setattr__"):
+    globs = {}
+
+    flags = dtbuild.get_flags(cls)
+    fields = dtbuild.get_fields(cls)
+
+    frozen_fields = set(
+        name for name, field in fields.items()
+        if getattr(field, "frozen", False)
+    )
+
+    globs["__frozen_fields"] = frozen_fields
+
+    if flags.get("slotted", True):
+        globs["__setattr_func"] = object.__setattr__
+        setattr_method = "__setattr_func(self, name, value)"
+        attrib_check = "hasattr(self, name)"
+    else:
+        setattr_method = "self.__dict__[name] = value"
+        attrib_check = "name in self.__dict__"
+
+    code = (
+        f"def {funcname}(self, name, value):\n"
+        f"    if name in __frozen_fields and {attrib_check}:\n"
+        f"        raise AttributeError(\n"
+        f"            f'Attribute {{name!r}} does not support assignment'\n"
+        f"        )\n"
+        f"    else:\n"
+        f"        {setattr_method}\n"
+    )
+
+    return dtbuild.GeneratedCode(code, globs)
+
+
+def delattr_generator(cls, funcname="__delattr__"):
+    globs = {}
+
+    flags = dtbuild.get_flags(cls)
+    fields = dtbuild.get_fields(cls)
+
+    frozen_fields = set(
+        name for name, field in fields.items()
+        if getattr(field, "frozen", False)
+    )
+
+    globs["__frozen_fields"] = frozen_fields
+
+    if flags.get("slotted", True):
+        globs["__delattr_func"] = object.__delattr__
+        delattr_method = "__delattr_func(self, name)"
+    else:
+        delattr_method = "del self.__dict__[name]"
+
+    code = (
+        f"def {funcname}(self, name):\n"
+        f"    if name in __frozen_fields:"
+        f"        raise AttributeError(\n"
+        f"            f'Attribute {{name!r}} is frozen and can not be deleted'\n"
+        f"        )\n"
+        f"    else:\n"
+        f"        {delattr_method}\n"
+    )
+
+    return dtbuild.GeneratedCode(code, globs)
+
+
+frozen_setattr_field_maker = dtbuild.MethodMaker("__setattr__", setattr_generator)
+frozen_delattr_field_maker = dtbuild.MethodMaker("__delattr__", delattr_generator)
+gatherer = dtbuild.make_unified_gatherer(FreezableField)
+
+
+def freezable(cls=None, /, *, frozen=False):
+    if cls is None:
+        return lambda cls_: freezable(cls_, frozen=frozen)
+
+    # To make a slotted class use a base class with metaclass
+    flags = {"frozen": frozen, "slotted": False}
+
+    cls = dtbuild.builder(
+        cls,
+        gatherer=gatherer,
+        methods=dtbuild.default_methods,
+        flags=flags,
+    )
+
+    # Frozen attributes need to be added afterwards
+    # Due to the need to know if frozen fields exist
+    if frozen:
+        setattr(cls, "__setattr__", dtbuild.frozen_setattr_maker)
+        setattr(cls, "__delattr__", dtbuild.frozen_delattr_maker)
+    else:
+        fields = dtbuild.get_fields(cls)
+        has_frozen_fields = False
+        for f in fields.values():
+            if getattr(f, "frozen", False):
+                has_frozen_fields = True
+                break
+
+        if has_frozen_fields:
+            setattr(cls, "__setattr__", frozen_setattr_field_maker)
+            setattr(cls, "__delattr__", frozen_delattr_field_maker)
+
+    return cls
+
+
+@freezable
+class X:
+    a: int = 2
+    b: int = FreezableField(default=12, frozen=True)
+
+
+x = X()
+x.a = 21
+
+try:
+    x.b = 43
+except AttributeError as e:
+    print(repr(e))
+```
+
 #### Converters ####
 
 Here's an implementation of basic converters that always convert when

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -743,7 +743,7 @@ def make_slot_gatherer(field_type=Field):
 
 def make_annotation_gatherer(
     field_type=Field,
-    leave_default_values=True,
+    leave_default_values=False,
 ):
     """
     Create a new annotation gatherer that will work with `Field` instances
@@ -809,7 +809,7 @@ def make_annotation_gatherer(
 
 def make_field_gatherer(
     field_type=Field,
-    leave_default_values=True,
+    leave_default_values=False,
 ):
     def field_attribute_gatherer(cls_or_ns):
         if isinstance(cls_or_ns, (_MappingProxyType, dict)):
@@ -842,7 +842,7 @@ def make_field_gatherer(
 
 def make_unified_gatherer(
     field_type=Field,
-    leave_default_values=True,
+    leave_default_values=False,
 ):
     """
     Create a gatherer that will work via first slots, then
@@ -892,7 +892,7 @@ annotation_gatherer = make_annotation_gatherer()
 
 # The unified gatherer used for slot classes must remove default
 # values for slots to work correctly.
-unified_gatherer = make_unified_gatherer(leave_default_values=False)
+unified_gatherer = make_unified_gatherer()
 
 
 # Now the gatherers have been defined, add __repr__ and __eq__ to Field.

--- a/tests/annotations/test_annotated.py
+++ b/tests/annotations/test_annotated.py
@@ -60,9 +60,10 @@ def test_annotation_gatherer():
     for key in "defgh":
         assert key not in annos
 
-    # Instance variables not removed from class
-    # Field replaced with default value on class
-    assert modifications["c"] == "c"
+    # Instance variables to be removed from class
+    assert modifications["a"] is NOTHING
+    assert modifications["b"] is NOTHING
+    assert modifications["c"] is NOTHING
 
 
 def test_make_annotation_gatherer():
@@ -71,7 +72,7 @@ def test_make_annotation_gatherer():
 
     gatherer = make_annotation_gatherer(
         field_type=NewField,
-        leave_default_values=False,
+        leave_default_values=True,
     )
 
     class ExampleAnnotated:
@@ -91,10 +92,11 @@ def test_make_annotation_gatherer():
 
     assert annos["blank_field"] == NewField(type=str)
 
-    # ABC should be present in annos but removed from the class
+    # ABC should be present in annos and in the class
     for key in "abc":
         assert annos[key] == NewField(default=key, type=annotations[key])
-        assert modifications[key] is NOTHING
+
+    assert modifications["c"] == "c"
 
     # Opposite for classvar
     for key in "defgh":


### PR DESCRIPTION
Add the example to the documentation.

As part of creating this example it became clear that the default behaviour of gatherers should be removing attributes as this makes them all compatible with the `SlotMakerMeta`.