### PR TITLE
Fix an issue with union annotations in Python 3.14

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -e .[testing]
+          python -m pip install -e .[testing,type_checking]
       - name: Check type stub files
         run: |
           python -m mypy.stubtest ducktools.classbuilder

--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13-dev", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8"]
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,18 @@ classifiers = [
 dynamic = ['version']
 license = {file = "LICENSE.md"}
 
+[project.optional-dependencies]
+testing = ["pytest>=8.2", "pytest-cov", "typing_extensions"]
+type_checking = ["mypy"]
+performance_tests = ["attrs", "pydantic"]
+docs = ["sphinx", "myst-parser", "sphinx_rtd_theme"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 
 [tool.setuptools_scm]
 version_file = "src/ducktools/classbuilder/_version.py"
 version_file_template = "__version__ = \"{version}\"\n__version_tuple__ = {version_tuple}\n"
-
-
-[project.optional-dependencies]
-testing = ["pytest>=8.2", "pytest-cov", "mypy", "typing_extensions"]
-performance_tests = ["attrs", "pydantic"]
-docs = ["sphinx", "myst-parser", "sphinx_rtd_theme"]
 
 [project.urls]
 "Homepage" = "https://github.com/davidcellis/ducktools-classbuilder"


### PR DESCRIPTION
Union annotations would cause an error if they did not evaluate in Python 3.14 as the individual elements would be converted to strings independently and then joined with '|' which would fail as it does not operate on strings.