### PR TITLE
Allow for attributes to be both kw_only and not in init.

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -654,11 +654,6 @@ class Field(metaclass=SlotMakerMeta):
                 f"{cls_name} cannot define both a default value and a default factory."
             )
 
-        if self.kw_only and not self.init:
-            raise AttributeError(
-                f"{cls_name} cannot be keyword only if it is not in init."
-            )
-
     @classmethod
     def from_field(cls, fld, /, **kwargs):
         """

--- a/tests/prefab/shared/examples/fails/creation_1.py
+++ b/tests/prefab/shared/examples/fails/creation_1.py
@@ -1,6 +1,0 @@
-from ducktools.classbuilder.prefab import prefab, attribute
-
-
-@prefab
-class Construct:
-    x = attribute(default="test", kw_only=True, init=False)

--- a/tests/prefab/shared/test_creation.py
+++ b/tests/prefab/shared/test_creation.py
@@ -144,15 +144,6 @@ class TestClassVar:
 
 
 class TestExceptions:
-    def test_kw_not_in_init(self):
-        with pytest.raises(AttributeError) as e_info:
-            from fails.creation_1 import Construct
-
-        assert (
-            e_info.value.args[0]
-            == "Attribute cannot be keyword only if it is not in init."
-        )
-
     def test_positional_after_kw_error(self):
         with pytest.raises(SyntaxError) as e_info:
             from fails.creation_2 import FailSyntax


### PR DESCRIPTION
Attributes should be able to be both kw_only and not in init so a `KW_ONLY` marker can be used while still allowing attributes that do not appear in `__init__` to be declared.