### PR TITLE
Simplifications and fixes for Python 3.14

### DIFF
--- a/.github/workflows/auto_test.yml
+++ b/.github/workflows/auto_test.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.13", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8"]
+        python-version: ["3.14-dev", "3.13", "3.12", "3.11", "3.10", "pypy-3.10", "3.9", "3.8"]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/ducktools/classbuilder/annotations.py
+++ b/src/ducktools/classbuilder/annotations.py
@@ -23,39 +23,12 @@ import sys
 
 
 class _LazyAnnotationLib:
-    def __init__(self):
-        if sys.version_info < (3, 14):
-            self.annotationlib_unavailable = True
-        else:
-            self.annotationlib_unavailable = None
-
     def __getattr__(self, item):
-        if self.annotationlib_unavailable:
-            raise ImportError("'annotationlib' is not available")
+        global _lazyannotationlib
+        import annotationlib
+        _lazyannotationlib = annotationlib
+        return getattr(annotationlib, item)
 
-        try:
-            import annotationlib
-        except ImportError:
-            self.annotationlib_unavailable = True
-            raise ImportError("'annotationlib' is not available")
-        else:
-            self.Format = annotationlib.Format
-            self.call_annotate_function = annotationlib.call_annotate_function
-
-            # This function keeps getting changed and renamed
-            get_ns_annotate = getattr(annotationlib, "get_annotate_from_class_namespace", None)
-            if get_ns_annotate is None:
-                get_ns_annotate = getattr(annotationlib, "get_annotate_function")
-            self.get_ns_annotate = get_ns_annotate
-
-            if item == "Format":
-                return self.Format
-            elif item == "call_annotate_function":
-                return self.call_annotate_function
-            elif item == "get_ns_annotate":
-                return get_ns_annotate
-
-        raise AttributeError(f"{item!r} is not available from this lazy importer")
 
 _lazy_annotationlib = _LazyAnnotationLib()
 
@@ -72,19 +45,14 @@ def get_ns_annotations(ns):
     annotations = ns.get("__annotations__")
     if annotations is not None:
         annotations = annotations.copy()
-    else:
-        try:
-            # See if we're using PEP-649 annotations
-            annotate = ns.get("__annotate__")  # Works in the early alphas
-            if not annotate:
-                annotate = _lazy_annotationlib.get_ns_annotate(ns)
-            if annotate:
-                annotations = _lazy_annotationlib.call_annotate_function(
-                    annotate,
-                    format=_lazy_annotationlib.Format.FORWARDREF
-                )
-        except ImportError:
-            pass
+    elif sys.version_info >= (3, 14):
+        # See if we're using PEP-649 annotations
+        annotate = _lazy_annotationlib.get_annotate_from_class_namespace(ns)
+        if annotate:
+            annotations = _lazy_annotationlib.call_annotate_function(
+                annotate,
+                format=_lazy_annotationlib.Format.FORWARDREF
+            )
 
     if annotations is None:
         annotations = {}
@@ -125,4 +93,3 @@ def is_classvar(hint):
             ):
                 return True
     return False
-

--- a/tests/py314_tests/_test_support.py
+++ b/tests/py314_tests/_test_support.py
@@ -1,0 +1,42 @@
+from annotationlib import ForwardRef
+
+# From test/support/__init__.py
+class EqualToForwardRef:
+    """Helper to ease use of annotationlib.ForwardRef in tests.
+
+    This checks only attributes that can be set using the constructor.
+
+    """
+
+    def __init__(
+        self,
+        arg,
+        *,
+        module=None,
+        owner=None,
+        is_class=False,
+    ):
+        self.__forward_arg__ = arg
+        self.__forward_is_class__ = is_class
+        self.__forward_module__ = module
+        self.__owner__ = owner
+
+    def __eq__(self, other):
+        if not isinstance(other, (EqualToForwardRef, ForwardRef)):
+            return NotImplemented
+        return (
+            self.__forward_arg__ == other.__forward_arg__
+            and self.__forward_module__ == other.__forward_module__
+            and self.__forward_is_class__ == other.__forward_is_class__
+            and self.__owner__ == other.__owner__
+        )
+
+    def __repr__(self):
+        extra = []
+        if self.__forward_module__ is not None:
+            extra.append(f", module={self.__forward_module__!r}")
+        if self.__forward_is_class__:
+            extra.append(", is_class=True")
+        if self.__owner__ is not None:
+            extra.append(f", owner={self.__owner__!r}")
+        return f"EqualToForwardRef({self.__forward_arg__!r}{''.join(extra)})"

--- a/tests/py314_tests/test_forwardref_annotations.py
+++ b/tests/py314_tests/test_forwardref_annotations.py
@@ -1,11 +1,13 @@
 # Bare forwardrefs only work in 3.14 or later
 
 from ducktools.classbuilder.annotations import get_ns_annotations
-from annotationlib import ForwardRef
 
 from pathlib import Path
 
+from _test_support import EqualToForwardRef
+
 global_type = int
+
 
 def test_bare_forwardref():
     class Ex:
@@ -15,7 +17,7 @@ def test_bare_forwardref():
 
     annos = get_ns_annotations(Ex.__dict__)
 
-    assert annos == {'a': str, 'b': Path, 'c': ForwardRef("plain_forwardref")}
+    assert annos == {'a': str, 'b': Path, 'c': EqualToForwardRef("plain_forwardref")}
 
 
 def test_inner_outer_ref():
@@ -38,7 +40,7 @@ def test_inner_outer_ref():
     cls, annos = make_func()
 
     # Forwardref given as string if used before it can be evaluated
-    assert annos == {"a_val": str, "b_val": int, "c_val": ForwardRef("hyper_type")}
+    assert annos == {"a_val": str, "b_val": int, "c_val": EqualToForwardRef("hyper_type")}
 
     # Correctly evaluated if it exists
     assert get_ns_annotations(cls.__dict__) == {


### PR DESCRIPTION
Simplifies the 3.14 logic by removing everything that only worked in specific alphas.

Adds 3.14 to the test matrix

Fixes the 3.14 tests.