### PR TITLE
Make the prefab decorator return type Any for now as trying to combine overloads and dataclass_transform crashes mypy.stubtest

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -33,7 +33,7 @@
 import os
 
 from .annotations import get_ns_annotations, is_classvar
-from ._version import __version__, __version_tuple__
+from ._version import __version__, __version_tuple__  # noqa: F401
 
 # Change this name if you make heavy modifications
 INTERNALS_DICT = "__classbuilder_internals__"
@@ -280,7 +280,7 @@ def get_init_generator(null=NOTHING, extra_code=None):
 
         assigns = "\n    ".join(assignments) if assignments else "pass\n"
         code = (
-            f"def {funcname}(self, {args}):\n" 
+            f"def {funcname}(self, {args}):\n"
             f"    {assigns}\n"
         )
         # Handle additional function calls
@@ -663,10 +663,10 @@ class Field(metaclass=SlotMakerMeta):
     def from_field(cls, fld, /, **kwargs):
         """
         Create an instance of field or subclass from another field.
-        
-        This is intended to be used to convert a base 
+
+        This is intended to be used to convert a base
         Field into a subclass.
-        
+
         :param fld: field class to convert
         :param kwargs: Additional keyword arguments for subclasses
         :return: new field subclass instance
@@ -762,7 +762,9 @@ def make_annotation_gatherer(
         else:
             cls_dict = cls_or_ns.__dict__
 
-        cls_fields: dict[str, field_type] = {}
+        # This should really be dict[str, field_type] but static analysis
+        # doesn't understand this.
+        cls_fields: dict[str, Field] = {}
         modifications = {}
 
         cls_annotations = get_ns_annotations(cls_dict)

--- a/src/ducktools/classbuilder/annotations.py
+++ b/src/ducktools/classbuilder/annotations.py
@@ -25,7 +25,7 @@ import sys
 class _LazyAnnotationLib:
     def __getattr__(self, item):
         global _lazyannotationlib
-        import annotationlib
+        import annotationlib  # type: ignore - this is a Python 3.14 library
         _lazyannotationlib = annotationlib
         return getattr(annotationlib, item)
 

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -36,7 +36,7 @@ from . import (
 
 # These aren't used but are re-exported for ease of use
 # noinspection PyUnresolvedReferences
-from . import SlotFields, KW_ONLY
+from . import SlotFields, KW_ONLY  # noqa: F401
 
 PREFAB_FIELDS = "PREFAB_FIELDS"
 PREFAB_INIT_FUNC = "__prefab_init__"

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -128,20 +128,39 @@ class Prefab(metaclass=SlotMakerMeta):
 
 # For some reason PyCharm can't see 'attribute'?!?
 # noinspection PyUnresolvedReferences
+@typing.overload
 @dataclass_transform(field_specifiers=(Attribute, attribute))
 def prefab(
-    cls: type[_T] | None = None,
+    cls: type[_T],
+    /,
     *,
-    init: bool = True,
-    repr: bool = True,
-    eq: bool = True,
-    iter: bool = False,
-    match_args: bool = True,
-    kw_only: bool = False,
-    frozen: bool = False,
-    dict_method: bool = False,
-    recursive_repr: bool = False,
-) -> type[_T] | Callable[[type[_T]], type[_T]]: ...
+    init: bool = ...,
+    repr: bool = ...,
+    eq: bool = ...,
+    iter: bool = ...,
+    match_args: bool = ...,
+    kw_only: bool = ...,
+    frozen: bool = ...,
+    dict_method: bool = ...,
+    recursive_repr: bool = ...,
+) -> type[_T]: ...
+
+@typing.overload
+@dataclass_transform(field_specifiers=(Attribute, attribute))
+def prefab(
+    cls: None = None,
+    /,
+    *,
+    init: bool = ...,
+    repr: bool = ...,
+    eq: bool = ...,
+    iter: bool = ...,
+    match_args: bool = ...,
+    kw_only: bool = ...,
+    frozen: bool = ...,
+    dict_method: bool = ...,
+    recursive_repr: bool = ...,
+) -> Callable[[type[_T]], type[_T]]: ...
 
 def build_prefab(
     class_name: str,

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -125,13 +125,45 @@ class Prefab(metaclass=SlotMakerMeta):
         recursive_repr: bool = False,
     ) -> None: ...
 
+# As far as I can tell these are the correct types
+# But mypy.stubtest crashes trying to analyse them
+# Due to the combination of overload and dataclass_transform
+# @typing.overload
+# def prefab(
+#     cls: None = None,
+#     *,
+#     init: bool = ...,
+#     repr: bool = ...,
+#     eq: bool = ...,
+#     iter: bool = ...,
+#     match_args: bool = ...,
+#     kw_only: bool = ...,
+#     frozen: bool = ...,
+#     dict_method: bool = ...,
+#     recursive_repr: bool = ...,
+# ) -> Callable[[type[_T]], type[_T]]: ...
 
-# For some reason PyCharm can't see 'attribute'?!?
-# noinspection PyUnresolvedReferences
-@typing.overload
+# @dataclass_transform(field_specifiers=(Attribute, attribute))
+# @typing.overload
+# def prefab(
+#     cls: type[_T],
+#     *,
+#     init: bool = ...,
+#     repr: bool = ...,
+#     eq: bool = ...,
+#     iter: bool = ...,
+#     match_args: bool = ...,
+#     kw_only: bool = ...,
+#     frozen: bool = ...,
+#     dict_method: bool = ...,
+#     recursive_repr: bool = ...,
+# ) -> type[_T]: ...
+
+# As mypy crashes, and the only difference is the return type
+# just return `Any` for now to avoid the overload.
 @dataclass_transform(field_specifiers=(Attribute, attribute))
 def prefab(
-    cls: type[_T],
+    cls: type[_T] | None = ...,
     *,
     init: bool = ...,
     repr: bool = ...,
@@ -142,23 +174,7 @@ def prefab(
     frozen: bool = ...,
     dict_method: bool = ...,
     recursive_repr: bool = ...,
-) -> type[_T]: ...
-
-@typing.overload
-@dataclass_transform(field_specifiers=(Attribute, attribute))
-def prefab(
-    cls: None = None,
-    *,
-    init: bool = ...,
-    repr: bool = ...,
-    eq: bool = ...,
-    iter: bool = ...,
-    match_args: bool = ...,
-    kw_only: bool = ...,
-    frozen: bool = ...,
-    dict_method: bool = ...,
-    recursive_repr: bool = ...,
-) -> Callable[[type[_T]], type[_T]]: ...
+) -> typing.Any: ...
 
 def build_prefab(
     class_name: str,

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -132,7 +132,6 @@ class Prefab(metaclass=SlotMakerMeta):
 @dataclass_transform(field_specifiers=(Attribute, attribute))
 def prefab(
     cls: type[_T],
-    /,
     *,
     init: bool = ...,
     repr: bool = ...,
@@ -149,7 +148,6 @@ def prefab(
 @dataclass_transform(field_specifiers=(Attribute, attribute))
 def prefab(
     cls: None = None,
-    /,
     *,
     init: bool = ...,
     repr: bool = ...,


### PR DESCRIPTION
Also some other linter appeasal and type fixes