### PR TITLE
Fix attribute type returns for field specifier

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -47,7 +47,7 @@ _UNDER_TESTING = os.environ.get("PYTEST_VERSION") is not None
 # Obtain types the same way types.py does in pypy
 # See: https://github.com/pypy/pypy/blob/19d9fa6be11165116dd0839b9144d969ab426ae7/lib-python/3/types.py#L61-L73
 class _C: __slots__ = 's'  # noqa
-_MemberDescriptorType = type(_C.s)  # noqa
+_MemberDescriptorType = type(_C.s)  # type: ignore
 _MappingProxyType = type(type.__dict__)
 del _C
 
@@ -959,24 +959,6 @@ def slotclass(cls=None, /, *, methods=default_methods, syntax_check=True):
         check_argument_order(cls)
 
     return cls
-
-
-class AnnotationClass(metaclass=SlotMakerMeta):
-    __slots__ = {}
-
-    def __init_subclass__(
-            cls,
-            methods=default_methods,
-            gatherer=unified_gatherer,
-            **kwargs
-    ):
-        # Check class dict otherwise this will always be True as this base
-        # class uses slots.
-        slots = "__slots__" in cls.__dict__
-
-        builder(cls, gatherer=gatherer, methods=methods, flags={"slotted": slots})
-        check_argument_order(cls)
-        super().__init_subclass__(**kwargs)
 
 
 @slotclass

--- a/src/ducktools/classbuilder/__init__.pyi
+++ b/src/ducktools/classbuilder/__init__.pyi
@@ -5,7 +5,6 @@ import inspect
 
 from collections.abc import Callable
 from types import MappingProxyType
-from typing_extensions import dataclass_transform
 
 _py_type = type | str  # Alias for type hint values
 _CopiableMappings = dict[str, typing.Any] | MappingProxyType[str, typing.Any]
@@ -243,18 +242,6 @@ def slotclass(
 
 
 _gatherer_type = Callable[[type | _CopiableMappings], tuple[dict[str, Field], dict[str, typing.Any]]]
-
-
-@dataclass_transform(field_specifiers=(Field,))
-class AnnotationClass(metaclass=SlotMakerMeta):
-    __slots__: dict
-
-    def __init_subclass__(
-        cls,
-        methods: frozenset[MethodMaker] | set[MethodMaker] = default_methods,
-        gatherer: _gatherer_type = unified_gatherer,
-        **kwargs,
-    ) -> None: ...
 
 class GatheredFields:
     __slots__: dict[str, None]

--- a/src/ducktools/classbuilder/annotations.py
+++ b/src/ducktools/classbuilder/annotations.py
@@ -25,7 +25,7 @@ import sys
 class _LazyAnnotationLib:
     def __getattr__(self, item):
         global _lazyannotationlib
-        import annotationlib  # type: ignore - this is a Python 3.14 library
+        import annotationlib  # type: ignore
         _lazyannotationlib = annotationlib
         return getattr(annotationlib, item)
 

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -294,7 +294,7 @@ class Attribute(Field):
     """
     iter: bool = True
     serialize: bool = True
-    metadata: dict = Field(default=FIELD_NOTHING, default_factory=dict)
+    metadata: dict = Field(default=FIELD_NOTHING, default_factory=dict)  # type: ignore
 
 
 # noinspection PyShadowingBuiltins
@@ -551,7 +551,7 @@ def _make_prefab(
 
 class Prefab(metaclass=SlotMakerMeta):
     _meta_gatherer = prefab_gatherer
-    __slots__ = {}
+    __slots__ = {}  # type: ignore
 
     # noinspection PyShadowingBuiltins
     def __init_subclass__(

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -4,7 +4,8 @@ from typing_extensions import dataclass_transform
 
 import inspect
 
-from collections.abc import Callable
+# Suppress weird pylance error
+from collections.abc import Callable  # type: ignore
 
 from . import (
     NOTHING,

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -58,36 +58,72 @@ class Attribute(Field):
         default: typing.Any | _NothingType = NOTHING,
         default_factory: typing.Any | _NothingType = NOTHING,
         type: type | _NothingType = NOTHING,
-        doc: str | None = None,
-        init: bool = True,
-        repr: bool = True,
-        compare: bool = True,
-        iter: bool = True,
-        kw_only: bool = False,
-        serialize: bool = True,
-        metadata: dict | None = None,
+        doc: str | None = ...,
+        init: bool = ...,
+        repr: bool = ...,
+        compare: bool = ...,
+        iter: bool = ...,
+        kw_only: bool = ...,
+        serialize: bool = ...,
+        metadata: dict | None = ...,
     ) -> None: ...
 
     def __repr__(self) -> str: ...
     def __eq__(self, other: Attribute | object) -> bool: ...
     def validate_field(self) -> None: ...
 
+@typing.overload
 def attribute(
     *,
-    default: typing.Any | _NothingType = NOTHING,
-    default_factory: typing.Any | _NothingType = NOTHING,
-    init: bool = True,
-    repr: bool = True,
-    compare: bool = True,
-    iter: bool = True,
-    kw_only: bool = False,
-    serialize: bool = True,
-    exclude_field: bool = False,
-    private: bool = False,
-    doc: str | None = None,
-    metadata: dict | None = None,
-    type: type | _NothingType = NOTHING,
-) -> Attribute: ...
+    default: _T,
+    default_factory: _NothingType = NOTHING,
+    init: bool = ...,
+    repr: bool = ...,
+    compare: bool = ...,
+    iter: bool = ...,
+    kw_only: bool = ...,
+    serialize: bool = ...,
+    exclude_field: bool = ...,
+    private: bool = ...,
+    doc: str | None = ...,
+    metadata: dict | None = ...,
+    type: type | _NothingType = ...,
+) -> _T: ...
+
+@typing.overload
+def attribute(
+    *,
+    default: _NothingType = NOTHING,
+    default_factory: Callable[[], _T],
+    init: bool = ...,
+    repr: bool = ...,
+    compare: bool = ...,
+    iter: bool = ...,
+    kw_only: bool = ...,
+    serialize: bool = ...,
+    exclude_field: bool = ...,
+    private: bool = ...,
+    doc: str | None = ...,
+    metadata: dict | None = ...,
+    type: type | _NothingType = ...,
+) -> _T: ...
+
+def attribute(
+    *,
+    default: _NothingType = NOTHING,
+    default_factory: _NothingType = NOTHING,
+    init: bool = ...,
+    repr: bool = ...,
+    compare: bool = ...,
+    iter: bool = ...,
+    kw_only: bool = ...,
+    serialize: bool = ...,
+    exclude_field: bool = ...,
+    private: bool = ...,
+    doc: str | None = ...,
+    metadata: dict | None = ...,
+    type: type | _NothingType = ...,
+) -> typing.Any: ...
 
 def prefab_gatherer(cls_or_ns: type | MappingProxyType) -> tuple[dict[str, Attribute], dict[str, typing.Any]]: ...
 

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -108,6 +108,7 @@ def attribute(
     type: type | _NothingType = ...,
 ) -> _T: ...
 
+@typing.overload
 def attribute(
     *,
     default: _NothingType = NOTHING,
@@ -147,7 +148,8 @@ _T = typing.TypeVar("_T")
 # noinspection PyUnresolvedReferences
 @dataclass_transform(field_specifiers=(Attribute, attribute))
 class Prefab(metaclass=SlotMakerMeta):
-    _meta_gatherer: Callable[[type | _CopiableMappings], tuple[dict[str, Field], dict[str, typing.Any]]]
+    _meta_gatherer: Callable[[type | _CopiableMappings], tuple[dict[str, Field], dict[str, typing.Any]]] = ...
+    __slots__: dict[str, typing.Any] = ...
     def __init_subclass__(
         cls,
         init: bool = True,

--- a/tests/annotations/test_annotated.py
+++ b/tests/annotations/test_annotated.py
@@ -4,14 +4,13 @@ does not interfere when wrapping ClassVar
 """
 
 import sys
-import pytest
 
 from typing import ClassVar
 from typing_extensions import Annotated
 
 from ducktools.classbuilder import (
     Field, SlotFields, NOTHING,
-    AnnotationClass, annotation_gatherer, make_annotation_gatherer
+    annotation_gatherer, make_annotation_gatherer
 )
 
 from ducktools.classbuilder.annotations import (
@@ -102,43 +101,3 @@ def test_make_annotation_gatherer():
     for key in "defgh":
         assert key not in annos
         assert key not in modifications
-
-
-def test_annotationclass():
-    class ExampleAnnotated(AnnotationClass, slots=False):
-        a: str = "a"
-        b: "list[str]" = "b"
-        c: Annotated[str, ""] = Field(default="c")
-
-        d: ClassVar[str] = "d"
-        e: Annotated[ClassVar[str], ""] = "e"
-        f: "Annotated[ClassVar[str], '']" = "f"
-        g: Annotated[Annotated[ClassVar[str], ""], ""] = "g"
-        h: Annotated[CV[str], ''] = "h"
-
-    for key in "abc":
-        assert key not in ExampleAnnotated.__dict__
-
-    for key in "defgh":
-        assert key in ExampleAnnotated.__dict__
-
-    ex = ExampleAnnotated()
-    for char in "abcdefgh":
-        assert getattr(ex, char) == char
-
-    ex2 = ExampleAnnotated()
-    ex3 = ExampleAnnotated("i", "j", "k")
-
-    assert ex == ex2
-    assert ex != ex3
-
-    prefix = "test_annotationclass.<locals>."
-    assert repr(ex) == f"{prefix}ExampleAnnotated(a='a', b='b', c='c')"
-
-
-def test_annotated_syntax_error():
-    with pytest.raises(SyntaxError):
-        class ExampleAnnotated(AnnotationClass):
-            a: str = "a"  # noqa: the error being highlighted is the error we are testing.
-            b: "list[str]"
-            c: Annotated[str, ""] = Field(default="c")

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -19,7 +19,6 @@ from ducktools.classbuilder import (
     slot_gatherer,
     slotclass,
 
-    AnnotationClass,
     Field,
     GatheredFields,
     GeneratedCode,
@@ -371,30 +370,6 @@ def test_slotclass_weakref():
     assert ref == inst.__weakref__
 
 
-def test_annotationclass_weakref():
-    import weakref
-
-    class WeakrefClass(AnnotationClass):
-        a: int = 1
-        b: int = 2
-        __weakref__: dict
-
-    flds = get_fields(WeakrefClass)
-    assert 'a' in flds
-    assert 'b' in flds
-    assert '__weakref__' not in flds
-
-    slots = WeakrefClass.__slots__
-    assert 'a' in slots
-    assert 'b' in slots
-    assert '__weakref__' in slots
-
-    # Test weakrefs can be created
-    inst = WeakrefClass()
-    ref = weakref.ref(inst)
-    assert ref == inst.__weakref__
-
-
 def test_slotclass_dict():
     @slotclass
     class DictClass:
@@ -403,28 +378,6 @@ def test_slotclass_dict():
             b=2,
             __dict__=None,
         )
-
-    flds = get_fields(DictClass)
-    assert 'a' in flds
-    assert 'b' in flds
-    assert '__dict__' not in flds
-
-    slots = DictClass.__slots__
-    assert 'a' in slots
-    assert 'b' in slots
-    assert '__dict__' in slots
-
-    # Test if __dict__ is included new values can be added
-    inst = DictClass()
-    inst.c = 42
-    assert inst.__dict__ == {"c": 42}
-
-
-def test_annotationclass_dict():
-    class DictClass(AnnotationClass):
-        a: int = 1
-        b: int = 2
-        __dict__: dict
 
     flds = get_fields(DictClass)
     assert 'a' in flds


### PR DESCRIPTION
Hopefully this fixes the issues with `attribute` returns, by lying about what it returns I guess. Seems to be how dataclasses' `field` function is defined though.