### PR TITLE
Rework SlotMakerMeta to create fields in an internal attribute

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -191,14 +191,13 @@ def reportclass(cls):
 slot_gatherer = dtbuild.make_slot_gatherer(CustomField)
 
 
-class ReportClass(metaclass=dtbuild.SlotMakerMeta):
+class ReportClass(metaclass=dtbuild.SlotMakerMeta, gatherer=fields_attribute_gatherer):
     __slots__ = {}
-    _meta_gatherer = fields_attribute_gatherer
-
+    
     def __init_subclass__(cls):
-        # Check if the metaclass has generated slots
-        meta_slotted = '__slots__' in vars(cls) and isinstance(cls.__slots__, dtbuild.SlotFields)
-        gatherer = slot_gatherer if meta_slotted else fields_attribute_gatherer
+        # Check if the metaclass has pre-gathered data
+        pre_gathered = dtbuild.GATHERED_DATA in vars(cls)
+        gatherer = dtbuild.pre_gathered_gatherer if pre_gathered else fields_attribute_gatherer
         methods = {
             dtbuild.eq_maker,
             dtbuild.repr_maker,

--- a/docs_code/docs_ex9_annotated.py
+++ b/docs_code/docs_ex9_annotated.py
@@ -6,9 +6,10 @@ from ducktools.classbuilder import (
     default_methods,
     get_fields,
     get_methods,
-    slot_gatherer,
+    pre_gathered_gatherer,
     Field,
     SlotMakerMeta,
+    GATHERED_DATA,
     NOTHING,
 )
 
@@ -110,16 +111,15 @@ def annotatedclass(cls=None, *, kw_only=False):
 
 
 # As a base class with slots
-class AnnotatedClass(metaclass=SlotMakerMeta):
-    # This attribute tells the slotmaker to use this gatherer
-    _meta_gatherer = annotated_gatherer
-
+class AnnotatedClass(metaclass=SlotMakerMeta, gatherer=annotated_gatherer):
+    
     def __init_subclass__(cls, kw_only=False, **kwargs):
+        pre_gathered = GATHERED_DATA in cls.__dict__
         slots = "__slots__" in cls.__dict__
 
         # if slots is True then fields will already be present in __slots__
         # Use the slot_gatherer for this case
-        gatherer = slot_gatherer if slots else annotated_gatherer
+        gatherer = pre_gathered_gatherer if pre_gathered else annotated_gatherer
 
         builder(
             cls,
@@ -139,10 +139,10 @@ if __name__ == "__main__":
     class X:
         x: str
         y: ClassVar[str] = "This should be ignored"
-        z: Annotated[ClassVar[str], "Should be ignored"] = "This should also be ignored"
-        a: Annotated[int, NO_INIT] = "Not In __init__ signature"
+        z: Annotated[ClassVar[str], "Should be ignored"] = "This should also be ignored"  # type: ignore
+        a: Annotated[int, NO_INIT] = "Not In __init__ signature"  # type: ignore
         b: Annotated[str, NO_REPR] = "Not In Repr"
-        c: Annotated[list[str], NO_COMPARE] = Field(default_factory=list)
+        c: Annotated[list[str], NO_COMPARE] = Field(default_factory=list)  # type: ignore
         d: Annotated[str, IGNORE_ALL] = "Not Anywhere"
         e: Annotated[str, KW_ONLY, NO_COMPARE]
 
@@ -150,23 +150,23 @@ if __name__ == "__main__":
     class Y(AnnotatedClass):
         x: str
         y: ClassVar[str] = "This should be ignored"
-        z: Annotated[ClassVar[str], "Should be ignored"] = "This should also be ignored"
-        a: Annotated[int, NO_INIT] = "Not In __init__ signature"
+        z: Annotated[ClassVar[str], "Should be ignored"] = "This should also be ignored"  # type: ignore
+        a: Annotated[int, NO_INIT] = "Not In __init__ signature"  # type: ignore
         b: Annotated[str, NO_REPR] = "Not In Repr"
-        c: Annotated[list[str], NO_COMPARE] = Field(default_factory=list)
+        c: Annotated[list[str], NO_COMPARE] = Field(default_factory=list)  # type: ignore
         d: Annotated[str, IGNORE_ALL] = "Not Anywhere"
         e: Annotated[str, KW_ONLY, NO_COMPARE]
 
 
     # Unslotted Demo
-    ex = X("Value of x", e="Value of e")
+    ex = X("Value of x", e="Value of e")  # type: ignore
     print(ex, "\n")
 
     pp(get_fields(X))
     print("\n")
 
     # Slotted Demo
-    ex = Y("Value of x", e="Value of e")
+    ex = Y("Value of x", e="Value of e")  # type: ignore
     print(ex, "\n")
 
     print(f"Slots: {Y.__dict__.get('__slots__')}")

--- a/docs_code/tutorial_code.py
+++ b/docs_code/tutorial_code.py
@@ -115,14 +115,13 @@ def reportclass(cls):
 slot_gatherer = dtbuild.make_slot_gatherer(CustomField)
 
 
-class ReportClass(metaclass=dtbuild.SlotMakerMeta):
+class ReportClass(metaclass=dtbuild.SlotMakerMeta, gatherer=fields_attribute_gatherer):
     __slots__ = {}
-    _meta_gatherer = fields_attribute_gatherer
-
+    
     def __init_subclass__(cls):
-        # Check if the metaclass has generated slots
-        meta_slotted = '__slots__' in vars(cls) and isinstance(cls.__slots__, dtbuild.SlotFields)
-        gatherer = slot_gatherer if meta_slotted else fields_attribute_gatherer
+        # Check if the metaclass has pre-gathered data
+        pre_gathered = dtbuild.GATHERED_DATA in vars(cls)
+        gatherer = dtbuild.pre_gathered_gatherer if pre_gathered else fields_attribute_gatherer
         methods = {
             dtbuild.eq_maker,
             dtbuild.repr_maker,
@@ -130,7 +129,6 @@ class ReportClass(metaclass=dtbuild.SlotMakerMeta):
             report_maker
         }
 
-        # The class may still have slots unrelated to code generation
         slotted = "__slots__" in vars(cls)
         flags = {"slotted": slotted}
 

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -116,7 +116,7 @@ FIELD_NOTHING = _NothingType("FIELD")
 # noinspection PyPep8Naming
 class _KW_ONLY_META(type):
     def __repr__(self):
-        return "<KW_ONLY Sentinel Object>"
+        return "<KW_ONLY Sentinel>"
 
 
 class KW_ONLY(metaclass=_KW_ONLY_META):

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -124,7 +124,6 @@ class KW_ONLY(metaclass=_KW_ONLY_META):
     Sentinel Class to indicate that variables declared after
     this sentinel are to be converted to KW_ONLY arguments.
     """
-    pass
 
 
 class GeneratedCode:

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -551,8 +551,7 @@ def _make_prefab(
     return cls
 
 
-class Prefab(metaclass=SlotMakerMeta):
-    _meta_gatherer = prefab_gatherer
+class Prefab(metaclass=SlotMakerMeta, gatherer=prefab_gatherer):
     __slots__ = {}  # type: ignore
 
     # noinspection PyShadowingBuiltins

--- a/src/ducktools/classbuilder/prefab.pyi
+++ b/src/ducktools/classbuilder/prefab.pyi
@@ -48,6 +48,7 @@ hash_maker: MethodMaker
 class Attribute(Field):
     __slots__: dict
     __signature__: inspect.Signature
+    __classbuilder_gathered_fields__: tuple[dict[str, Field], dict[str, typing.Any]]
 
     iter: bool
     serialize: bool

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,10 @@
 import sys
+from pathlib import Path
+
+
+_helpers = str(Path(__file__).parent / "helpers")
+sys.path.insert(0, _helpers)
+
 
 collect_ignore: list[str] = []
 

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -1,0 +1,7 @@
+import sys
+import pytest
+
+graalpy_fails = pytest.mark.xfail(
+    condition=sys.implementation.name == "graalpy",
+    reason="GraalPy does not support mappings in __slots__, it converts them to lists."
+)

--- a/tests/prefab/test_construction.py
+++ b/tests/prefab/test_construction.py
@@ -5,6 +5,9 @@ from ducktools.classbuilder.annotations import get_ns_annotations
 from ducktools.classbuilder.prefab import build_prefab, prefab, attribute, PrefabError
 
 
+from utils import graalpy_fails  # type: ignore
+
+
 def test_build_basic_prefab():
     DynamicTestClass = build_prefab(
         "DynamicTestClass",
@@ -94,6 +97,7 @@ def test_kwonly_class():
         c: int = attribute()  # kw_only should be ignored
 
 
+@graalpy_fails
 def test_build_slotted():
     SlottedClass = build_prefab(
         "SlottedClass",

--- a/tests/prefab/test_dunders.py
+++ b/tests/prefab/test_dunders.py
@@ -3,6 +3,8 @@
 import pytest
 from ducktools.classbuilder.prefab import attribute, prefab, SlotFields
 
+from utils import graalpy_fails  # type: ignore
+
 
 # Classes with REPR checks
 @prefab
@@ -64,6 +66,7 @@ def test_iter():
     assert y == [1, 2]
 
 
+@graalpy_fails
 def test_iter_exclude():
     @prefab(iter=True)
     class IterExcludeEmpty:

--- a/tests/prefab/test_funcs.py
+++ b/tests/prefab/test_funcs.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from ducktools.classbuilder.prefab import prefab, attribute, SlotFields
 from ducktools.classbuilder.prefab import is_prefab, is_prefab_instance, as_dict
 
+from utils import graalpy_fails  # type: ignore
+
 
 @prefab
 class Coordinate:
@@ -54,6 +56,7 @@ def test_as_dict():
     assert as_dict(y) == expected_dict
 
 
+@graalpy_fails
 def test_as_dict_excludes():
     @prefab
     class ExcludesUncached:

--- a/tests/prefab/test_slotted_class.py
+++ b/tests/prefab/test_slotted_class.py
@@ -3,7 +3,12 @@ import pytest
 from ducktools.classbuilder.annotations import get_ns_annotations
 from ducktools.classbuilder.prefab import prefab, attribute, SlotFields
 
+import pytest
 
+from utils import graalpy_fails  # type: ignore
+
+
+@graalpy_fails
 def test_basic_slotted():
     @prefab
     class SlottedPrefab:
@@ -20,6 +25,7 @@ def test_basic_slotted():
     assert ex.y == 3.14
 
 
+@graalpy_fails
 def test_class_unchanged():
     # By using slots to define the class prefab_classes does not need to create
     # a new class.
@@ -43,6 +49,7 @@ def test_class_unchanged():
     assert ex.x == "new example data"
 
 
+@graalpy_fails
 def test_actually_slotted():
     @prefab
     class Slotted:
@@ -62,6 +69,7 @@ def test_actually_slotted():
     inst.x = "This Works!"
 
 
+@graalpy_fails
 def test_slotted_inheritance():
     # This is an example that didn't work in attrs/dataclasses
     # https://github.com/python/cpython/issues/90562
@@ -69,7 +77,7 @@ def test_slotted_inheritance():
 
     @prefab
     class A:
-        __slots__ = SlotFields()
+        __slots__ = SlotFields(break_graal=False)
 
         def test(self):
             return type(self)
@@ -82,7 +90,7 @@ def test_slotted_inheritance():
     assert B().test() is B
 
     # Additional tests to prove slottedness of base class
-    ex = A()
+    ex = A(break_graal=True)
     with pytest.raises(AttributeError):
         ex.attrib = True
 
@@ -91,6 +99,7 @@ def test_slotted_inheritance():
     exb.attrib = True
 
 
+@graalpy_fails
 def test_slotted_frozen():
     @prefab(frozen=True)
     class A:

--- a/tests/prefab/test_subclass_implementation.py
+++ b/tests/prefab/test_subclass_implementation.py
@@ -5,6 +5,10 @@ import pytest
 from ducktools.classbuilder.prefab import Prefab, Attribute, SlotFields, get_attributes
 
 
+from utils import graalpy_fails  # type: ignore
+
+
+@graalpy_fails
 class TestConstructionForms:
     """
     Test the 3 different ways of constructing prefabs
@@ -180,6 +184,7 @@ class TestClassArguments:
         assert params['b'].default == 1
 
 
+@graalpy_fails
 def test_slots_weakref():
     import weakref
 

--- a/tests/prefab/test_subclass_implementation.py
+++ b/tests/prefab/test_subclass_implementation.py
@@ -186,7 +186,7 @@ def test_slots_weakref():
     class WeakrefClass(Prefab):
         a: int = 1
         b: int = 2
-        __weakref__: dict
+        __weakref__: dict  # type: ignore
 
     flds = get_attributes(WeakrefClass)
     assert 'a' in flds
@@ -208,7 +208,7 @@ def test_has_dict():
     class DictClass(Prefab):
         a: int = 1
         b: int = 2
-        __dict__: dict
+        __dict__: dict  # type: ignore
 
     flds = get_attributes(DictClass)
     assert 'a' in flds

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -27,6 +27,8 @@ from ducktools.classbuilder import (
 )
 from ducktools.classbuilder.annotations import get_ns_annotations
 
+from utils import graalpy_fails  # type: ignore
+
 
 def test_get_fields_flags_methods():
     local_fields = {"Example": Field()}
@@ -191,6 +193,7 @@ def test_frozen_unslotted():
         ex.b = "goodbye"
 
 
+@graalpy_fails
 def test_slot_gatherer_success():
 
     fields = {
@@ -237,6 +240,7 @@ def test_slot_gatherer_failure():
         slot_gatherer(DictSlots)
 
 
+@graalpy_fails
 def test_slotclass_empty():
     @slotclass
     class SlotClass:
@@ -249,6 +253,7 @@ def test_slotclass_empty():
     assert ex == ex2
 
 
+@graalpy_fails
 def test_slotclass_methods():
 
     class SlotClass:
@@ -265,6 +270,7 @@ def test_slotclass_methods():
     assert "__eq__" in SlotClass.__dict__
 
 
+@graalpy_fails
 def test_slotclass_attributes():
     @slotclass
     class SlotClass:
@@ -298,6 +304,7 @@ def test_slotclass_attributes():
     assert repr(ex3) == f"{prefix}SlotClass(a=1, b=2, c=[1, 2, 3])"
 
 
+@graalpy_fails
 def test_slotclass_nodefault():
     @slotclass
     class SlotClass:
@@ -319,6 +326,7 @@ def test_slotclass_nodefault():
     assert ex2.c == [8, 16, 32]
 
 
+@graalpy_fails
 def test_slotclass_ordering():
     with pytest.raises(SyntaxError):
         # Non-default argument after default
@@ -330,6 +338,7 @@ def test_slotclass_ordering():
             )
 
 
+@graalpy_fails
 def test_slotclass_norepr_noeq():
     @slotclass(methods={init_maker})
     class SlotClass:
@@ -343,6 +352,7 @@ def test_slotclass_norepr_noeq():
     assert "__eq__" not in SlotClass.__dict__
 
 
+@graalpy_fails
 def test_slotclass_weakref():
     import weakref
 
@@ -370,6 +380,7 @@ def test_slotclass_weakref():
     assert ref == inst.__weakref__
 
 
+@graalpy_fails
 def test_slotclass_dict():
     @slotclass
     class DictClass:
@@ -447,6 +458,7 @@ def test_fieldclass_frozen():
         delattr(f, "new_attribute")
 
 
+@graalpy_fails
 def test_builder_noclass():
     mini_slotclass = builder(gatherer=slot_gatherer, methods={init_maker})
 
@@ -500,6 +512,7 @@ def test_gatheredfields():
     )
 
 
+@graalpy_fails
 def test_signature():
     # This used to fail
     @slotclass
@@ -509,6 +522,7 @@ def test_signature():
     assert str(inspect.signature(SigClass)) == "(x=42)"
 
 
+@graalpy_fails
 def test_subclass_method_not_overwritten():
     @slotclass
     class X:

--- a/tests/test_field_flags.py
+++ b/tests/test_field_flags.py
@@ -1,7 +1,10 @@
 from ducktools.classbuilder import Field, SlotFields, slotclass
 import inspect
 
+from utils import graalpy_fails  # type: ignore
 
+
+@graalpy_fails
 def test_init_false_field():
     @slotclass
     class Example:
@@ -20,6 +23,7 @@ def test_init_false_field():
     assert ex.y == "y"
 
 
+@graalpy_fails
 def test_repr_false_field():
     @slotclass
     class Example:
@@ -32,6 +36,7 @@ def test_repr_false_field():
     assert repr(ex).endswith("Example(y='y')")
 
 
+@graalpy_fails
 def test_compare_false_field():
     @slotclass
     class Example:
@@ -48,6 +53,7 @@ def test_compare_false_field():
     assert ex != ex3
 
 
+@graalpy_fails
 def test_kwonly_true_field():
     @slotclass
     class Example:

--- a/tests/test_slotmakermeta.py
+++ b/tests/test_slotmakermeta.py
@@ -1,6 +1,6 @@
 from typing import Annotated, ClassVar, List
 
-from ducktools.classbuilder import Field, SlotFields, NOTHING, SlotMakerMeta
+from ducktools.classbuilder import Field, SlotFields, NOTHING, SlotMakerMeta, GATHERED_DATA
 
 import pytest
 
@@ -19,13 +19,20 @@ def test_slots_created():
     assert hasattr(ExampleAnnotated, "__slots__")
 
     slots = ExampleAnnotated.__slots__  # noqa
-    expected_slots = SlotFields({
-        "a": Field(default="a", type=str),
-        "b": Field(default="b", type="List[str]"),
-        "c": Field(default="c", type=Annotated[str, ""])
-    })
+    expected_slots = {"a": None, "b": None, "c": None}
 
     assert slots == expected_slots
+
+    expected_fields = {
+        "a": Field(default="a", type=str), 
+        "b": Field(default="b", type="List[str]"), 
+        "c": Field(default="c", type=Annotated[str, ""]),
+    }
+
+    fields, modifications = getattr(ExampleAnnotated, GATHERED_DATA)
+
+    assert fields == expected_fields
+    assert modifications == {}
 
 
 def test_slots_correct_subclass():
@@ -37,12 +44,8 @@ def test_slots_correct_subclass():
     class ExampleChild(ExampleBase):
         d: str = "d"
 
-    assert ExampleBase.__slots__ == SlotFields(    # noqa
-        a=Field(type=str),
-        b=Field(default="b", type=str),
-        c=Field(default="c", type=str),
-    )
-    assert ExampleChild.__slots__ == SlotFields(d=Field(default="d", type=str))  # noqa
+    assert ExampleBase.__slots__ == {"a": None, "b": None, "c": None}
+    assert ExampleChild.__slots__ == {"d": None}
 
     inst = ExampleChild()
 
@@ -63,7 +66,11 @@ def test_slots_attribute():
         y: str = Field(default="y")
         z = Field(default="z")
 
-    assert ExampleBase.__slots__ == SlotFields(  # noqa
-        y=Field(default="y", type=str),
-        z=Field(default="z"),
-    )
+    assert ExampleBase.__slots__ == {"y": None, "z": None}
+
+
+def test_made_doc():
+    class ExampleBase(metaclass=SlotMakerMeta):
+        x: str = Field(doc="Test")
+
+    assert ExampleBase.__slots__ == {"x": "Test"}

--- a/tests/test_slotmakermeta.py
+++ b/tests/test_slotmakermeta.py
@@ -4,7 +4,10 @@ from ducktools.classbuilder import Field, SlotFields, NOTHING, SlotMakerMeta, GA
 
 import pytest
 
+from utils import graalpy_fails  # type: ignore
 
+
+@graalpy_fails
 def test_slots_created():
     class ExampleAnnotated(metaclass=SlotMakerMeta):
         a: str = "a"
@@ -35,6 +38,7 @@ def test_slots_created():
     assert modifications == {}
 
 
+@graalpy_fails
 def test_slots_correct_subclass():
     class ExampleBase(metaclass=SlotMakerMeta):
         a: str
@@ -58,6 +62,7 @@ def test_slots_correct_subclass():
         inst.e = "e"
 
 
+@graalpy_fails
 def test_slots_attribute():
     # In the case where an unannotated field is declared, ignore
     # annotations without field values.
@@ -69,6 +74,7 @@ def test_slots_attribute():
     assert ExampleBase.__slots__ == {"y": None, "z": None}
 
 
+@graalpy_fails
 def test_made_doc():
     class ExampleBase(metaclass=SlotMakerMeta):
         x: str = Field(doc="Test")


### PR DESCRIPTION
SlotMakerMeta now creates fields in __classbuilder_gathered_fields__ instead of putting all of the data in __slots__ to be re-gathered.

This means that classes that don't use the slot gatherer should now work in GraalPy, but it also just seems cleaner to not modify `__slots__` after class creation.

`__slots__` is now a mapping with the field name and any 'doc' attributes, GraalPy will convert this into a list and lose the documentation (as of GraalPy 24.2.1).

A number of tests which expect the mapping to remain in place will still fail in GraalPy and have been marked as such.