### PR TITLE
Generate an __annotate__ function for __init__ to hide internals from help()

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -33,7 +33,7 @@
 import os
 import sys
 
-from .annotations import get_ns_annotations, is_classvar
+from .annotations import get_ns_annotations, is_classvar, make_annotate_func
 from ._version import __version__, __version_tuple__  # noqa: F401
 
 # Change this name if you make heavy modifications
@@ -208,7 +208,11 @@ class MethodMaker:
 
         # Apply annotations
         if gen.annotations is not None:
-            method.__annotations__ = gen.annotations
+            if sys.version_info >= (3, 14):
+                anno_func = make_annotate_func(gen.annotations)
+                method.__annotate__ = anno_func
+            else:
+                method.__annotations__ = gen.annotations
 
         # Replace this descriptor on the class with the generated function
         setattr(gen_cls, self.funcname, method)

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -31,6 +31,7 @@
 # Field itself sidesteps this by defining __slots__ to avoid that branch.
 
 import os
+import sys
 
 from .annotations import get_ns_annotations, is_classvar
 from ._version import __version__, __version_tuple__  # noqa: F401
@@ -131,19 +132,25 @@ class GeneratedCode:
     This class provides a return value for the generated output from source code
     generators.
     """
-    __slots__ = ("source_code", "globs")
+    __slots__ = ("source_code", "globs", "annotations")
 
-    def __init__(self, source_code, globs):
+    def __init__(self, source_code, globs, annotations=None):
         self.source_code = source_code
         self.globs = globs
+        self.annotations = annotations
 
     def __repr__(self):
         first_source_line = self.source_code.split("\n")[0]
-        return f"GeneratorOutput(source_code='{first_source_line} ...', globs={self.globs!r})"
+        return (
+            f"GeneratorOutput(source_code='{first_source_line} ...', "
+            f"globs={self.globs!r}, annotations={self.annotations!r})"
+        )
 
     def __eq__(self, other):
         if self.__class__ is other.__class__:
-            return (self.source_code, self.globs) == (other.source_code, other.globs)
+            return (self.source_code, self.globs, self.annotations) == (
+                other.source_code, other.globs, other.annotations
+            )
         return NotImplemented
 
 
@@ -198,6 +205,10 @@ class MethodMaker:
             # This might be a property or some other special
             # descriptor. Don't try to rename.
             pass
+
+        # Apply annotations
+        if gen.annotations is not None:
+            method.__annotations__ = gen.annotations
 
         # Replace this descriptor on the class with the generated function
         setattr(gen_cls, self.funcname, method)

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -209,8 +209,14 @@ class MethodMaker:
         # Apply annotations
         if gen.annotations is not None:
             if sys.version_info >= (3, 14):
-                anno_func = make_annotate_func(gen.annotations)
-                method.__annotate__ = anno_func
+                # If __annotations__ exists on the class, either they
+                # are user defined or they are using __future__ annotations.
+                # In this case, just write __annotations__
+                if "__annotations__" in gen_cls.__dict__:
+                    method.__annotations__ = gen.annotations
+                else:
+                    anno_func = make_annotate_func(gen.annotations)
+                    method.__annotate__ = anno_func
             else:
                 method.__annotations__ = gen.annotations
 

--- a/src/ducktools/classbuilder/__init__.pyi
+++ b/src/ducktools/classbuilder/__init__.pyi
@@ -40,15 +40,19 @@ class KW_ONLY(metaclass=_KW_ONLY_META): ...
 class _CodegenType(typing.Protocol):
     def __call__(self, cls: type, funcname: str = ...) -> GeneratedCode: ...
 
-
 class GeneratedCode:
-    __slots__: tuple[str, str]
+    __slots__: tuple[str, ...]
     source_code: str
     globs: dict[str, typing.Any]
+    annotations: dict[str, typing.Any]
 
-    def __init__(self, source_code: str, globs: dict[str, typing.Any]) -> None: ...
+    def __init__(
+        self,
+        source_code: str,
+        globs: dict[str, typing.Any],
+        annotations: dict[str, typing.Any] | None = ...,
+    ) -> None: ...
     def __repr__(self) -> str: ...
-
 
 class MethodMaker:
     funcname: str

--- a/src/ducktools/classbuilder/annotations.py
+++ b/src/ducktools/classbuilder/annotations.py
@@ -90,7 +90,7 @@ def make_annotate_func(annos):
     Format = _lazy_annotationlib.Format
     ForwardRef = _lazy_annotationlib.ForwardRef
     # Construct an annotation function from __annotations__
-    def annotate_func(format):
+    def annotate_func(format, /):
         match format:
             case Format.VALUE | Format.FORWARDREF:
                 return {

--- a/src/ducktools/classbuilder/annotations.pyi
+++ b/src/ducktools/classbuilder/annotations.pyi
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 import typing
 import types
 
@@ -10,6 +11,10 @@ def get_func_annotations(
 def get_ns_annotations(
     ns: _CopiableMappings,
 ) -> dict[str, typing.Any]: ...
+
+def make_annotate_func(
+    annos: dict[str, typing.Any]
+) -> Callable[[int], dict[str, typing.Any]]: ...
 
 def is_classvar(
     hint: object,

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -195,7 +195,7 @@ def init_generator(cls, funcname="__init__"):
         post_init_call = ""
 
     code = (
-        f"def {funcname}(self, {args}) -> None:\n"
+        f"def {funcname}(self, {args}):\n"
         f"{pre_init_call}\n"
         f"{body}\n"
         f"{post_init_call}\n"

--- a/src/ducktools/classbuilder/prefab.py
+++ b/src/ducktools/classbuilder/prefab.py
@@ -64,6 +64,7 @@ def get_attributes(cls):
 # Method Generators
 def init_generator(cls, funcname="__init__"):
     globs = {}
+    annotations = {}
     # Get the internals dictionary and prepare attributes
     attributes = get_attributes(cls)
     flags = get_flags(cls)
@@ -106,41 +107,29 @@ def init_generator(cls, funcname="__init__"):
     kw_only_arglist = []
     for name, attrib in attributes.items():
         # post_init annotations can be used to broaden types.
-        if name in post_init_annotations:
-            globs[f"_{name}_type"] = post_init_annotations[name]
-        elif attrib.type is not NOTHING:
-            globs[f"_{name}_type"] = attrib.type
-
         if attrib.init:
+            if name in post_init_annotations:
+                annotations[name] = post_init_annotations[name]
+            elif attrib.type is not NOTHING:
+                annotations[name] = attrib.type
+
             if attrib.default is not NOTHING:
                 if isinstance(attrib.default, (str, int, float, bool)):
                     # Just use the literal in these cases
-                    if attrib.type is NOTHING:
-                        arg = f"{name}={attrib.default!r}"
-                    else:
-                        arg = f"{name}: _{name}_type = {attrib.default!r}"
+                    arg = f"{name}={attrib.default!r}"
                 else:
                     # No guarantee repr will work for other objects
                     # so store the value in a variable and put it
                     # in the globals dict for eval
-                    if attrib.type is NOTHING:
-                        arg = f"{name}=_{name}_default"
-                    else:
-                        arg = f"{name}: _{name}_type = _{name}_default"
+                    arg = f"{name}=_{name}_default"
                     globs[f"_{name}_default"] = attrib.default
             elif attrib.default_factory is not NOTHING:
                 # Use NONE here and call the factory later
                 # This matches the behaviour of compiled
-                if attrib.type is NOTHING:
-                    arg = f"{name}=None"
-                else:
-                    arg = f"{name}: _{name}_type = None"
+                arg = f"{name}=None"
                 globs[f"_{name}_factory"] = attrib.default_factory
             else:
-                if attrib.type is NOTHING:
-                    arg = name
-                else:
-                    arg = f"{name}: _{name}_type"
+                arg = name
             if attrib.kw_only or kw_only:
                 kw_only_arglist.append(arg)
             else:
@@ -212,7 +201,13 @@ def init_generator(cls, funcname="__init__"):
         f"{post_init_call}\n"
     )
 
-    return GeneratedCode(code, globs)
+    if annotations:
+        annotations["return"] = None
+    else:
+        # If there are no annotations, return an unannotated init function
+        annotations = None
+
+    return GeneratedCode(code, globs, annotations)
 
 
 def iter_generator(cls, funcname="__iter__"):

--- a/tests/py314_tests/test_init_signature.py
+++ b/tests/py314_tests/test_init_signature.py
@@ -1,0 +1,122 @@
+from annotationlib import get_annotations, Format
+
+import pytest
+
+
+from ducktools.classbuilder.prefab import Prefab, prefab
+from _test_support import EqualToForwardRef
+
+
+# Aliases for alias test
+assign_int = int
+type type_str = str
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": str, "y": int}),
+        (Format.FORWARDREF, {"return": None, "x": str, "y": int}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "int"}),
+    ]
+)
+def test_resolvable_annotations(format, expected):
+    @prefab
+    class Example:
+        x: str
+        y: int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+    class Example(Prefab):
+        x: str
+        y: int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": str, "y": int}),
+        (Format.FORWARDREF, {"return": None, "x": str, "y": int}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "late_definition"}),
+    ]
+)
+def test_late_defined_annotations(format, expected):
+    # Test where the annotation is a forwardref at processing time
+    @prefab
+    class Example:
+        x: str
+        y: late_definition
+
+    late_definition = int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": int, "y": type_str}),
+        (Format.FORWARDREF, {"return": None, "x": int, "y": type_str}),
+        (Format.STRING, {"return": "None", "x": "int", "y": "type_str"}),
+    ]
+)
+def test_alias_defined_annotations(format, expected):
+    # Test the behaviour of type aliases and regular types
+    # Type Alias names should be kept while regular assignments will be lost
+
+    @prefab
+    class Example:
+        x: assign_int  # type: ignore
+        y: type_str
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.FORWARDREF, {"return": None, "x": str, "y": EqualToForwardRef("undefined")}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "undefined"}),
+    ]
+)
+def test_forwardref_annotation(format, expected):
+    # Test where the annotation is a forwardref at processing and analysis
+    class Example(Prefab):
+        x: str
+        y: undefined
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+def test_forwardref_raises():
+    # Should still raise a NameError with VALUE annotations
+    @prefab
+    class Example:
+        x: str
+        y: undefined
+
+    with pytest.raises(NameError):
+        annos = get_annotations(Example.__init__, format=Format.VALUE)
+
+
+def test_raises_with_fake_globals():
+    @prefab
+    class Example:
+        x: str
+        y: undefined
+
+    with pytest.raises(NotImplementedError):
+        annos = Example.__init__.__annotate__(Format.VALUE_WITH_FAKE_GLOBALS)

--- a/tests/py314_tests/test_init_signature_future.py
+++ b/tests/py314_tests/test_init_signature_future.py
@@ -1,0 +1,105 @@
+# The same tests as test_init_signature but under the __future__ annotations import
+from __future__ import annotations
+
+from annotationlib import get_annotations, Format
+
+import pytest
+
+
+from ducktools.classbuilder.prefab import Prefab, prefab
+from _test_support import EqualToForwardRef
+
+
+# Aliases for alias test
+assign_int = int
+type type_str = str
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": "str", "y": "int"}),
+        (Format.FORWARDREF, {"return": None, "x": "str", "y": "int"}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "int"}),
+    ]
+)
+def test_resolvable_annotations(format, expected):
+    @prefab
+    class Example:
+        x: str
+        y: int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+    class Example(Prefab):
+        x: str
+        y: int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": "str", "y": "late_definition"}),
+        (Format.FORWARDREF, {"return": None, "x": "str", "y": "late_definition"}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "late_definition"}),
+    ]
+)
+def test_late_defined_annotations(format, expected):
+    # Test where the annotation is a forwardref at processing time
+    @prefab
+    class Example:
+        x: str
+        y: late_definition
+
+    late_definition = int
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": "assign_int", "y": "type_str"}),
+        (Format.FORWARDREF, {"return": None, "x": "assign_int", "y": "type_str"}),
+        (Format.STRING, {"return": "None", "x": "assign_int", "y": "type_str"}),
+    ]
+)
+def test_alias_defined_annotations(format, expected):
+    # Test the behaviour of type aliases and regular types
+    # under __future__ annotations both should be kept
+
+    @prefab
+    class Example:
+        x: assign_int  # type: ignore
+        y: type_str
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected
+
+
+@pytest.mark.parametrize(
+    ["format", "expected"],
+    [
+        (Format.VALUE, {"return": None, "x": "str", "y": "undefined"}),
+        (Format.FORWARDREF, {"return": None, "x": "str", "y": "undefined"}),
+        (Format.STRING, {"return": "None", "x": "str", "y": "undefined"}),
+    ]
+)
+def test_forwardref_annotation(format, expected):
+    # Test where the annotation is a forwardref at processing and analysis
+    class Example(Prefab):
+        x: str
+        y: undefined
+
+    annos = get_annotations(Example.__init__, format=format)
+
+    assert annos == expected


### PR DESCRIPTION
When help is called on a generated class, currently the annotations defined in the code string for `__init__` are shown. These all have internal names and are not helpful. This is a side effect of `Format.STRING` annotation evaluation.

To work around this, annotations are no longer included in the source code, but are attached as an `__annotate__` function to `__init__`. This also means ForwardRef values no longer leak into `__init__.__annotations__`.