### PR TITLE
Better string annotations results from generated annotate methods

### DIFF
--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -215,7 +215,7 @@ class MethodMaker:
                 if "__annotations__" in gen_cls.__dict__:
                     method.__annotations__ = gen.annotations
                 else:
-                    anno_func = make_annotate_func(gen.annotations)
+                    anno_func = make_annotate_func(gen_cls, gen.annotations)
                     method.__annotate__ = anno_func
             else:
                 method.__annotations__ = gen.annotations

--- a/src/ducktools/classbuilder/__init__.py
+++ b/src/ducktools/classbuilder/__init__.py
@@ -216,6 +216,7 @@ class MethodMaker:
                     method.__annotations__ = gen.annotations
                 else:
                     anno_func = make_annotate_func(gen_cls, gen.annotations)
+                    anno_func.__qualname__ = f"{gen_cls.__qualname__}.{self.funcname}.__annotate__"
                     method.__annotate__ = anno_func
             else:
                 method.__annotations__ = gen.annotations

--- a/src/ducktools/classbuilder/annotations.py
+++ b/src/ducktools/classbuilder/annotations.py
@@ -91,7 +91,7 @@ def make_annotate_func(cls, annos):
     Format = _lazy_annotationlib.Format
     ForwardRef = _lazy_annotationlib.ForwardRef
     # Construct an annotation function from __annotations__
-    def annotate_func(format, /):
+    def __annotate__(format, /):
         match format:
             case Format.VALUE | Format.FORWARDREF:
                 return {
@@ -110,11 +110,12 @@ def make_annotate_func(cls, annos):
                     try:
                         string_annos[k] = cls_annotations[k]
                     except KeyError:
+                        # Likely a return value
                         string_annos[k] = type_repr(v)
                 return string_annos
             case _:
                 raise NotImplementedError(format)
-    return annotate_func
+    return __annotate__
 
 
 def is_classvar(hint):

--- a/src/ducktools/classbuilder/annotations.pyi
+++ b/src/ducktools/classbuilder/annotations.pyi
@@ -13,6 +13,7 @@ def get_ns_annotations(
 ) -> dict[str, typing.Any]: ...
 
 def make_annotate_func(
+    cls: type,
     annos: dict[str, typing.Any]
 ) -> Callable[[int], dict[str, typing.Any]]: ...
 

--- a/tests/py314_tests/test_init_signature.py
+++ b/tests/py314_tests/test_init_signature.py
@@ -39,6 +39,14 @@ def test_resolvable_annotations(format, expected):
     assert annos == expected
 
 
+def test_annotate_qualname():
+    @prefab
+    class Example:
+        x: str
+
+    assert Example.__init__.__annotate__.__qualname__ == f"{Example.__qualname__}.__init__.__annotate__"
+
+
 @pytest.mark.parametrize(
     ["format", "expected"],
     [

--- a/tests/py314_tests/test_init_signature.py
+++ b/tests/py314_tests/test_init_signature.py
@@ -66,12 +66,12 @@ def test_late_defined_annotations(format, expected):
     [
         (Format.VALUE, {"return": None, "x": int, "y": type_str}),
         (Format.FORWARDREF, {"return": None, "x": int, "y": type_str}),
-        (Format.STRING, {"return": "None", "x": "int", "y": "type_str"}),
+        (Format.STRING, {"return": "None", "x": "assign_int", "y": "type_str"}),
     ]
 )
 def test_alias_defined_annotations(format, expected):
     # Test the behaviour of type aliases and regular types
-    # Type Alias names should be kept while regular assignments will be lost
+    # Both names should be kept in string annotations
 
     @prefab
     class Example:
@@ -99,6 +99,15 @@ def test_forwardref_annotation(format, expected):
     annos = get_annotations(Example.__init__, format=format)
 
     assert annos == expected
+
+
+def test_contained_string_annotation():
+    class Example(Prefab):
+        x: list[undefined]
+
+    annos = get_annotations(Example.__init__, format=Format.STRING)
+
+    assert annos == {"return": "None", "x": "list[undefined]"}
 
 
 def test_forwardref_raises():


### PR DESCRIPTION
`list[undefined]` will now be `"list[undefined]"` instead of `"list[ForwardRef('undefined')]"`

Matches the work done for dataclasses here - https://github.com/python/cpython/pull/137711