### PR TITLE
Attempt to fix the publishing workflow

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -89,5 +89,5 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${GITHUB_REF_NAME}' dist/**
-        --repo '${GITHUB_REPOSITORY}'
+        \'${GITHUB_REF_NAME}\' dist/**
+        --repo \'${GITHUB_REPOSITORY}\'

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -89,5 +89,5 @@ jobs:
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        \'${GITHUB_REF_NAME}\' dist/**
-        --repo \'${GITHUB_REPOSITORY}\'
+        "${GITHUB_REF_NAME}" dist/**
+        --repo "${GITHUB_REPOSITORY}"


### PR DESCRIPTION
The single quotes around environment variables broke the release workflow. Using double quotes should allow the variables to work correctly.